### PR TITLE
fix: ingress annotations for ceph and argocd

### DIFF
--- a/apps/base/argocd/ingress.yaml
+++ b/apps/base/argocd/ingress.yaml
@@ -4,9 +4,9 @@ metadata:
   name: argocd-ingress
   namespace: argocd
   annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
   ingressClassName: nginx
   rules:

--- a/infrastructure/configs/ceph-cluster.yaml
+++ b/infrastructure/configs/ceph-cluster.yaml
@@ -36,9 +36,9 @@ spec:
       dashboard:
         ingressClassName: nginx
         annotations:
+          nginx.ingress.kubernetes.io/ssl-redirect: "true"
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-          nginx.ingress.kubernetes.io/server-snippet: |
-            proxy_ssl_verify off;
+          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
         host:
           name: rook-ceph.sharmamohit.com
           path: "/"


### PR DESCRIPTION
Since we don't allow snippet annotation via nginx ingress controller (due to CVE -https://github.com/kubernetes/kubernetes/issues/126811), adding `server-snippet` was causing nginx controller to err and ignore the annotation.
This was causing ingress to never reach healthy status.