### PR TITLE
chore: Helm upgrades and GitOps best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Decrypted secrets (should never be committed)
+*.dec.yaml
+*.decrypted.yaml
+
+# Temporary files
+*.tmp
+*.bak

--- a/agents.md
+++ b/agents.md
@@ -75,7 +75,7 @@ flux bootstrap github --token-auth --owner=Mohitsharma44 --repository=homeops --
 
 ## HelmRelease Structure
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: <name>

--- a/apps/base/argocd/argo-workflows-hr.yaml
+++ b/apps/base/argocd/argo-workflows-hr.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: argo-workflows
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: argo-workflows
+      version: "0.x"
       sourceRef:
         kind: HelmRepository
         name: argo-helm

--- a/apps/base/argocd/argocd-events-hr.yaml
+++ b/apps/base/argocd/argocd-events-hr.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: argo-events
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: argo-events
+      version: "2.x"
       sourceRef:
         kind: HelmRepository
         name: argo-helm

--- a/apps/base/argocd/argocd-hr.yaml
+++ b/apps/base/argocd/argocd-hr.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: argo-cd
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: argo-cd
+      version: "7.x"
       sourceRef:
         kind: HelmRepository
         name: argo-helm

--- a/apps/base/argocd/argocd-rollouts-hr.yaml
+++ b/apps/base/argocd/argocd-rollouts-hr.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: argo-rollouts
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: argo-rollouts
+      version: "2.x"
       sourceRef:
         kind: HelmRepository
         name: argo-helm

--- a/clusters/minipcs/apps.yaml
+++ b/clusters/minipcs/apps.yaml
@@ -15,3 +15,7 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/infrastructure/configs/ceph-cluster.yaml
+++ b/infrastructure/configs/ceph-cluster.yaml
@@ -1,22 +1,25 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph-cluster
   namespace: rook-ceph
 spec:
+  interval: 30m
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: 1.9.x
+      version: "1.16.x"
       sourceRef:
         kind: HelmRepository
         name: rook-release
         namespace: flux-system
-  interval: 30m
+      interval: 12h
   timeout: 10m
   install:
     remediation:
       retries: 3
+    crds: CreateReplace
   upgrade:
     remediation:
       retries: -1 # keep trying to remediate
@@ -31,7 +34,7 @@ spec:
     cephClusterSpec:
       storage:
         useAllNodes: true
-        userAllDevices: true
+        useAllDevices: true
     ingress:
       dashboard:
         ingressClassName: nginx

--- a/infrastructure/controllers/ingress-nginx/hr.yaml
+++ b/infrastructure/controllers/ingress-nginx/hr.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: "*"
+      version: "4.x"
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx

--- a/infrastructure/controllers/rook-ceph/hr.yaml
+++ b/infrastructure/controllers/rook-ceph/hr.yaml
@@ -1,28 +1,31 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
+  interval: 30m
   chart:
     spec:
       chart: rook-ceph
-      version: 1.9.x
+      version: "1.16.x"
       sourceRef:
         kind: HelmRepository
         name: rook-release
         namespace: flux-system
-  interval: 30m
+      interval: 12h
   timeout: 10m
   install:
     remediation:
       retries: 3
+    crds: CreateReplace
   upgrade:
     remediation:
       retries: -1 # keep trying to remediate
     crds: CreateReplace # Upgrade CRDs on package update
   releaseName: rook-ceph
   values:
-    pspEnable: false
+    # PSP removed in Kubernetes 1.25+ and rook-ceph 1.10+
     monitoring:
       enabled: false

--- a/infrastructure/controllers/rook-ceph/repo.yaml
+++ b/infrastructure/controllers/rook-ceph/repo.yaml
@@ -1,4 +1,5 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+---
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: rook-release


### PR DESCRIPTION
## Summary
Updates all HelmReleases to stable API versions, pins chart versions, and upgrades rook-ceph from 1.9.x to 1.16.x.

## What Changed
- Added `.gitignore` for IDE/OS/temp files
- Added SOPS decryption config to apps Kustomization
- Updated all HelmRelease APIs: `v2beta1`/`v2beta2` → `v2`
- Updated HelmRepository API: `v1beta1` → `v1`
- Pinned chart versions (minor wildcard): argo-cd 7.x, ingress-nginx 4.x, rook-ceph 1.16.x
- Removed deprecated `pspEnable` from rook-ceph
- Fixed typo `userAllDevices` → `useAllDevices` in ceph-cluster

## Verification Steps
1. `flux get helmreleases -A` - all should reconcile without API deprecation warnings
2. `kubectl get pods -n rook-ceph` - operator + cluster pods healthy after rook upgrade
3. `ceph status` via toolbox - cluster health OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)