### PR TITLE
fix: disable Helm wait for ingress-nginx to break circular dependency

### DIFF
--- a/infrastructure/controllers/ingress-nginx/hr.yaml
+++ b/infrastructure/controllers/ingress-nginx/hr.yaml
@@ -6,6 +6,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   interval: 30m
+  timeout: 5m
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: ingress-nginx


### PR DESCRIPTION
## Summary
- Add `disableWait: true` to ingress-nginx HelmRelease install/upgrade
- Add retry remediation (3 retries) for install and upgrade

## Problem
Circular dependency on fresh cluster bootstrap:
```
infra-controllers waits for ingress-nginx Helm install
  → Helm waits for Service to get LoadBalancer IP
    → LoadBalancer IP needs MetalLB IPAddressPool
      → IPAddressPool is in infra-configs
        → infra-configs waits for infra-controllers ← deadlock
```

## Fix
`disableWait: true` tells Helm not to block on the Service getting its LoadBalancer IP. The install completes, `infra-controllers` finishes, `infra-configs` applies the MetalLB `IPAddressPool`, and MetalLB assigns the IP shortly after.

## Test plan
- [ ] `flux get kustomizations` — `infra-controllers` progresses to Ready
- [ ] `kubectl get svc -n ingress-nginx` — controller Service gets `192.168.11.90`
- [ ] `flux get helmreleases -A` — ingress-nginx shows Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)