### PR TITLE
fix: split apps into two stages to resolve ArgoCD CRD ordering

### DIFF
--- a/apps/minipcs/kustomization.yaml
+++ b/apps/minipcs/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   # ArgoCD itself (deployed by Flux)
   - argocd
-  # App-of-Apps root application (deploys ArgoCD Applications)
-  - ../argocd-apps
-  # NOTE: podinfo is now managed by ArgoCD via App-of-Apps pattern
-  # Do not add it here - see apps/argocd-apps/apps/podinfo.yaml
+  # NOTE: root-app and ArgoCD Applications are deployed separately
+  # via the apps-config Flux Kustomization (see clusters/minipcs/apps.yaml)
+  # to avoid CRD ordering issues on fresh bootstrap

--- a/clusters/minipcs/apps.yaml
+++ b/clusters/minipcs/apps.yaml
@@ -19,3 +19,20 @@ spec:
     provider: sops
     secretRef:
       name: sops-age
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-config
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  dependsOn:
+    - name: apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./apps/argocd-apps
+  prune: true
+  timeout: 5m0s


### PR DESCRIPTION
## Summary
- Split the `apps` Flux Kustomization into `apps` (ArgoCD) and `apps-config` (root-app)
- Remove `argocd-apps` reference from `apps/minipcs/kustomization.yaml`
- Add new `apps-config` Flux Kustomization in `clusters/minipcs/apps.yaml` that depends on `apps`

## Problem
Same CRD ordering issue as cert-manager/MetalLB. The ArgoCD `Application` CR (`root-app.yaml`) is applied in the same Flux Kustomization as the ArgoCD HelmRelease. On fresh bootstrap, the `Application` CRD doesn't exist yet:
```
Application/argocd/root-app dry-run failed: no matches for kind "Application" in version "argoproj.io/v1alpha1"
```

## Fix
Two-stage deployment:
```
apps (ArgoCD HelmRelease → installs CRDs) → apps-config (root-app Application CR)
```

## Test plan
- [ ] `flux get kustomizations` — both `apps` and `apps-config` show Ready
- [ ] `kubectl get applications -n argocd` — `root-app` exists
- [ ] ArgoCD UI shows synced applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)