### PR TITLE
fix: enable MetalLB L2 announcements on Talos control plane nodes

### DIFF
--- a/infrastructure/configs/ipaddressPool.yaml
+++ b/infrastructure/configs/ipaddressPool.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - 192.168.11.88 - 192.168.11.98
+  - 192.168.11.88-192.168.11.98
 
 ---
 apiVersion: metallb.io/v1beta1

--- a/infrastructure/controllers/metallb/hr.yaml
+++ b/infrastructure/controllers/metallb/hr.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: metallb
-      version: "0.14.5"
+      version: "0.15.3"
       sourceRef:
         kind: HelmRepository
         name: metallb
@@ -19,6 +19,7 @@ spec:
     speaker:
       frr:
         enabled: false
+      ignoreExcludeLB: true
     prometheus:
       serviceMonitor:
         enabled: false

--- a/infrastructure/controllers/metallb/hr.yaml
+++ b/infrastructure/controllers/metallb/hr.yaml
@@ -16,6 +16,9 @@ spec:
         namespace: metallb-system
       interval: 12h
   values:
+    speaker:
+      frr:
+        enabled: false
     prometheus:
       serviceMonitor:
         enabled: false


### PR DESCRIPTION
## Summary
- Add `speaker.ignoreExcludeLB=true` to MetalLB Helm values to allow L2 announcements from Talos control plane nodes
- Fix IPAddressPool address range format (remove spaces around hyphen)
- Bump MetalLB chart version from 0.14.5 to 0.15.3

## Root Cause
Talos Linux sets `node.kubernetes.io/exclude-from-external-load-balancers` label on control plane nodes by default. MetalLB v0.13.2+ honors this label and won't announce from labeled nodes. On clusters where all nodes are control-plane/worker combinations, this results in zero eligible nodes for L2 announcements.

## Test plan
- [x] Applied changes locally via `helm upgrade`
- [x] Verified speaker logs show `serviceAnnounced` events
- [x] Verified service events show `announcing from node "talosXX" with protocol "layer2"`
- [x] Verified HTTP connectivity to LoadBalancer IP 192.168.11.90

🤖 Generated with [Claude Code](https://claude.com/claude-code)