### PR TITLE
fix: reduce Ceph object store PG count for 3-OSD cluster

### DIFF
--- a/infrastructure/configs/ceph-cluster.yaml
+++ b/infrastructure/configs/ceph-cluster.yaml
@@ -35,6 +35,36 @@ spec:
       storage:
         useAllNodes: true
         useAllDevices: true
+    cephObjectStores:
+      - name: ceph-objectstore
+        spec:
+          metadataPool:
+            failureDomain: host
+            replicated:
+              size: 3
+          dataPool:
+            failureDomain: host
+            erasureCoded:
+              dataChunks: 2
+              codingChunks: 1
+            parameters:
+              bulk: "true"
+              pg_num: "64"
+          preservePoolsOnDelete: true
+          gateway:
+            port: 80
+            instances: 1
+            priorityClassName: system-cluster-critical
+            resources:
+              requests:
+                cpu: "1"
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+        storageClass:
+          enabled: true
+          name: ceph-bucket
+          reclaimPolicy: Delete
     ingress:
       dashboard:
         ingressClassName: nginx


### PR DESCRIPTION
## Summary
- Configure `cephObjectStores` declaratively in rook-ceph-cluster Helm values
- Set `pg_num: "64"` for the erasure-coded data pool (reduced from 128)
- Resolves `TOO_MANY_PGS` warning (was 265 > max 250 per OSD)

## Why 64 PGs is appropriate

With 64 PGs for the EC pool, total PG distribution across 3 OSDs:

| Pool | pg_num | × size | PG mappings |
|------|--------|--------|-------------|
| ceph-objectstore.rgw.buckets.data (EC) | **64** | ×3 | 192 |
| ceph-blockpool | 32 | ×3 | 96 |
| ceph-filesystem-data0 | 32 | ×3 | 96 |
| ceph-filesystem-metadata | 16 | ×3 | 48 |
| 8 × RGW auxiliary pools | 8 each | ×3 | 192 |
| .mgr | 1 | ×3 | 3 |
| **Total** | | | **627** |

**627 ÷ 3 OSDs = 209 PGs per OSD** ✓ (within recommended 100-250 range)

## Note on verbosity
The full `cephObjectStores` spec is included because Helm lists replace entirely rather than merge. Specifying only the `pg_num` parameter would cause other fields to be missing.

## Test plan
- [x] Applied `ceph osd pool set ceph-objectstore.rgw.buckets.data pg_num 64` manually
- [x] Verified PG merge in progress (pg_num dropping from 128 → 64)
- [x] Cluster health warning will clear once merge completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)