### PR TITLE
feat: Phase 3 - K8s Observability Stack

### DIFF
--- a/apps/argocd-apps/apps/alloy.yaml
+++ b/apps/argocd-apps/apps/alloy.yaml
@@ -1,0 +1,112 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alloy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: alloy
+    targetRevision: "1.x"
+    helm:
+      valuesObject:
+        alloy:
+          configMap:
+            content: |
+              // Kubernetes pod discovery
+              discovery.kubernetes "pods" {
+                role = "pod"
+              }
+
+              // Relabel pod metadata for log labels
+              discovery.relabel "pod_logs" {
+                targets = discovery.kubernetes.pods.targets
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_phase"]
+                  regex         = "Pending|Succeeded|Failed|Unknown"
+                  action        = "drop"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_namespace"]
+                  target_label  = "namespace"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_name"]
+                  target_label  = "pod"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_container_name"]
+                  target_label  = "container"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_node_name"]
+                  target_label  = "node"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                  target_label  = "app"
+                }
+              }
+
+              // Collect pod logs via Kubernetes API
+              loki.source.kubernetes "pod_logs" {
+                targets    = discovery.relabel.pod_logs.output
+                forward_to = [loki.write.default.receiver]
+              }
+
+              // Write logs to Loki
+              loki.write "default" {
+                endpoint {
+                  url       = "http://loki.monitoring.svc:3100/loki/api/v1/push"
+                  tenant_id = "homelab"
+                }
+              }
+
+              // OTLP receiver for application traces
+              otelcol.receiver.otlp "default" {
+                grpc {
+                  endpoint = "0.0.0.0:4317"
+                }
+                http {
+                  endpoint = "0.0.0.0:4318"
+                }
+                output {
+                  traces = [otelcol.exporter.otlp.tempo.input]
+                }
+              }
+
+              // Forward traces to Tempo
+              otelcol.exporter.otlp "tempo" {
+                client {
+                  endpoint = "tempo.monitoring.svc:4317"
+                  tls {
+                    insecure = true
+                  }
+                }
+              }
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              memory: 384Mi
+        controller:
+          type: daemonset
+        serviceMonitor:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true

--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -1,0 +1,148 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: kube-prometheus-stack
+    targetRevision: "81.x"
+    helm:
+      valuesObject:
+        prometheus:
+          prometheusSpec:
+            retention: 3d
+            retentionSize: 15GB
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: ceph-block
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 20Gi
+            externalLabels:
+              cluster: minipcs
+              environment: homelab
+            serviceMonitorSelectorNilUsesHelmValues: false
+            podMonitorSelectorNilUsesHelmValues: false
+            ruleSelectorNilUsesHelmValues: false
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                memory: 4Gi
+            thanos:
+              objectStorageConfig:
+                name: thanos-objstore-secret
+                key: objstore.yml
+          thanosService:
+            enabled: true
+          thanosServiceMonitor:
+            enabled: true
+        grafana:
+          ingress:
+            enabled: true
+            ingressClassName: nginx
+            hosts:
+              - grafana.sharmamohit.com
+          sidecar:
+            datasources:
+              defaultDatasourceEnabled: false
+            dashboards:
+              enabled: true
+              searchNamespace: monitoring
+          additionalDataSources:
+            - name: Thanos
+              type: prometheus
+              uid: thanos
+              url: http://thanos-query.monitoring.svc:9090
+              access: proxy
+              isDefault: true
+            - name: Loki
+              type: loki
+              uid: loki
+              url: http://loki.monitoring.svc:3100
+              access: proxy
+              jsonData:
+                httpHeaderName1: "X-Scope-OrgID"
+                derivedFields:
+                  - datasourceUid: tempo
+                    matcherRegex: "(?:traceID|trace_id|traceid)=(\\w+)"
+                    name: TraceID
+                    url: "${__value.raw}"
+              secureJsonData:
+                httpHeaderValue1: "homelab"
+            - name: Tempo
+              type: tempo
+              uid: tempo
+              url: http://tempo.monitoring.svc:3100
+              access: proxy
+              jsonData:
+                tracesToLogs:
+                  datasourceUid: loki
+                  filterByTraceID: true
+          persistence:
+            enabled: true
+            storageClassName: ceph-block
+            size: 2Gi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+        alertmanager:
+          alertmanagerSpec:
+            retention: 120h
+            storage:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: ceph-block
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 1Gi
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+        nodeExporter:
+          enabled: true
+        prometheus-node-exporter:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+        kubeStateMetrics:
+          enabled: true
+        kube-state-metrics:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/argocd-apps/apps/loki.yaml
+++ b/apps/argocd-apps/apps/loki.yaml
@@ -1,0 +1,100 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: loki
+    targetRevision: "6.x"
+    helm:
+      valuesObject:
+        deploymentMode: SingleBinary
+        loki:
+          auth_enabled: true
+          commonConfig:
+            replication_factor: 1
+          schemaConfig:
+            configs:
+              - from: "2024-01-01"
+                store: tsdb
+                object_store: s3
+                schema: v13
+                index:
+                  prefix: loki_index_
+                  period: 24h
+          storage:
+            type: s3
+            s3:
+              endpoint: seaweedfs.sharmamohit.com:8333
+              region: us-east-1
+              s3ForcePathStyle: true
+              insecure: true
+            bucketNames:
+              chunks: loki-chunks
+              ruler: loki-ruler
+          limits_config:
+            retention_period: 720h
+          compactor:
+            retention_enabled: true
+        singleBinary:
+          replicas: 1
+          persistence:
+            storageClass: ceph-block
+            size: 10Gi
+          extraEnv:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-s3-secret
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-s3-secret
+                  key: aws-secret-access-key
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+        read:
+          replicas: 0
+        write:
+          replicas: 0
+        backend:
+          replicas: 0
+        gateway:
+          enabled: false
+        chunksCache:
+          enabled: false
+        resultsCache:
+          enabled: false
+        lokiCanary:
+          enabled: false
+        test:
+          enabled: false
+        monitoring:
+          selfMonitoring:
+            enabled: false
+            grafanaAgent:
+              installOperator: false
+          serviceMonitor:
+            enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true

--- a/apps/argocd-apps/apps/loki.yaml
+++ b/apps/argocd-apps/apps/loki.yaml
@@ -22,7 +22,7 @@ spec:
             replication_factor: 1
           schemaConfig:
             configs:
-              - from: "2024-01-01"
+              - from: "2026-01-01"
                 store: tsdb
                 object_store: s3
                 schema: v13

--- a/apps/argocd-apps/apps/tempo.yaml
+++ b/apps/argocd-apps/apps/tempo.yaml
@@ -1,0 +1,69 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: tempo
+    targetRevision: "1.x"
+    helm:
+      valuesObject:
+        tempo:
+          storage:
+            trace:
+              backend: s3
+              s3:
+                bucket: tempo-traces
+                endpoint: seaweedfs.sharmamohit.com:8333
+                insecure: true
+                forcepathstyle: true
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: "0.0.0.0:4317"
+                http:
+                  endpoint: "0.0.0.0:4318"
+          compactor:
+            compaction:
+              block_retention: 168h
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+        persistence:
+          enabled: true
+          storageClassName: ceph-block
+          size: 10Gi
+        serviceMonitor:
+          enabled: true
+        extraEnv:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: seaweedfs-s3-secret
+                key: aws-access-key-id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: seaweedfs-s3-secret
+                key: aws-secret-access-key
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true

--- a/apps/argocd-apps/apps/tempo.yaml
+++ b/apps/argocd-apps/apps/tempo.yaml
@@ -24,6 +24,7 @@ spec:
                 endpoint: seaweedfs.sharmamohit.com:8333
                 insecure: true
                 forcepathstyle: true
+                region: us-east-1
           receivers:
             otlp:
               protocols:

--- a/apps/argocd-apps/apps/thanos.yaml
+++ b/apps/argocd-apps/apps/thanos.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: thanos
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: thanos
+    targetRevision: "17.x"
+    helm:
+      valuesObject:
+        existingObjstoreSecret: thanos-objstore-secret
+        query:
+          enabled: true
+          dnsDiscovery:
+            enabled: true
+            sidecarsService: "kube-prometheus-stack-thanos-discovery"
+            sidecarsNamespace: "monitoring"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+        storegateway:
+          enabled: true
+          persistence:
+            enabled: true
+            storageClass: ceph-block
+            size: 10Gi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+        compactor:
+          enabled: true
+          retentionResolutionRaw: 7d
+          retentionResolution5m: 30d
+          retentionResolution1h: 180d
+          persistence:
+            enabled: true
+            storageClass: ceph-block
+            size: 10Gi
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+        queryFrontend:
+          enabled: false
+        ruler:
+          enabled: false
+        receive:
+          enabled: false
+        bucketweb:
+          enabled: false
+        metrics:
+          enabled: true
+          serviceMonitor:
+            enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true

--- a/infrastructure/configs/DEPLOYMENT-monitoring.md
+++ b/infrastructure/configs/DEPLOYMENT-monitoring.md
@@ -1,0 +1,184 @@
+# Phase 3: K8s Observability Stack Deployment
+
+## Overview
+
+Full metrics/logs/traces observability stack deployed in the `monitoring` namespace via ArgoCD, with long-term storage on SeaweedFS S3 (TrueNAS).
+
+## Components
+
+| Component | Chart | Version | Purpose |
+|-----------|-------|---------|---------|
+| kube-prometheus-stack | prometheus-community | 81.x | Prometheus, Grafana, Alertmanager, node-exporter, kube-state-metrics |
+| Thanos | bitnami/thanos | 17.x | Long-term metrics (Query, Store Gateway, Compactor) |
+| Loki | grafana/loki | 6.x | Log aggregation (SingleBinary mode) |
+| Tempo | grafana/tempo | 1.x | Distributed tracing (monolithic mode) |
+| Alloy | grafana/alloy | 1.x | Log collection + trace forwarding (DaemonSet) |
+
+## Architecture
+
+```
+                          ┌─────────────────────────────────────────┐
+                          │              Grafana                     │
+                          │     grafana.sharmamohit.com              │
+                          │  Datasources: Thanos, Loki, Tempo       │
+                          └──────┬──────────┬──────────┬────────────┘
+                                 │          │          │
+                    ┌────────────▼┐   ┌─────▼───┐  ┌──▼───┐
+                    │ Thanos Query│   │  Loki   │  │Tempo │
+                    └──────┬──────┘   │ Single  │  │Mono  │
+                           │          │ Binary  │  │lithic│
+              ┌────────────┼───┐      └────┬────┘  └──┬───┘
+              │            │   │           │          │
+    ┌─────────▼──┐  ┌──────▼─┐ │     ┌─────▼────┐  ┌─▼──────────┐
+    │Store       │  │Thanos  │ │     │SeaweedFS │  │ SeaweedFS  │
+    │Gateway     │  │Sidecar │ │     │loki-*    │  │tempo-traces│
+    └─────┬──────┘  └────────┘ │     └──────────┘  └────────────┘
+          │                    │
+    ┌─────▼──────────┐  ┌─────▼────┐
+    │  SeaweedFS     │  │Compactor │
+    │  thanos-metrics│  └──────────┘
+    └────────────────┘
+
+    Alloy DaemonSet ──→ Logs to Loki, Traces to Tempo
+```
+
+## Endpoints
+
+| Service | URL / Address |
+|---------|---------------|
+| Grafana | https://grafana.sharmamohit.com |
+| Prometheus | http://kube-prometheus-stack-prometheus.monitoring.svc:9090 |
+| Thanos Query | http://thanos-query.monitoring.svc:9090 |
+| Loki | http://loki.monitoring.svc:3100 |
+| Tempo HTTP | http://tempo.monitoring.svc:3100 |
+| Tempo OTLP gRPC | tempo.monitoring.svc:4317 |
+| Tempo OTLP HTTP | http://tempo.monitoring.svc:4318 |
+| Alertmanager | http://kube-prometheus-stack-alertmanager.monitoring.svc:9093 |
+
+## S3 Backend (SeaweedFS on TrueNAS)
+
+- **Endpoint**: http://seaweedfs.sharmamohit.com:8333
+- **IAM Identity**: observability (Read/Write/List)
+- **Buckets**: thanos-metrics, loki-chunks, loki-ruler, tempo-traces
+
+## Secrets
+
+Two SOPS-encrypted secrets in `infrastructure/configs/`:
+
+| Secret | Namespace | Keys | Used By |
+|--------|-----------|------|---------|
+| `seaweedfs-s3-secret` | monitoring | `aws-access-key-id`, `aws-secret-access-key` | Loki, Tempo (via env vars) |
+| `thanos-objstore-secret` | monitoring | `objstore.yml` | Prometheus Thanos sidecar, Thanos components |
+
+**Credential rotation note**: Both secrets contain the same SeaweedFS observability IAM credentials. When rotating credentials, update **both** `seaweedfs-s3-secret` and `thanos-objstore-secret`, then re-encrypt with SOPS.
+
+## Retention Policy
+
+| Data Type | Hot (NVMe) | Cold (SeaweedFS/HDD) |
+|-----------|-----------|---------------------|
+| Metrics (raw) | 3 days | 7 days |
+| Metrics (5m downsample) | — | 30 days |
+| Metrics (1h downsample) | — | 180 days |
+| Logs | — | 30 days |
+| Traces | — | 7 days |
+
+## Storage (Ceph PVCs)
+
+| Component | Size | StorageClass |
+|-----------|------|-------------|
+| Prometheus | 20Gi | ceph-block |
+| Alertmanager | 1Gi | ceph-block |
+| Thanos Store Gateway | 10Gi | ceph-block |
+| Thanos Compactor | 10Gi | ceph-block |
+| Loki WAL | 10Gi | ceph-block |
+| Tempo WAL | 10Gi | ceph-block |
+| Grafana | 2Gi | ceph-block |
+| **Total** | **63Gi** | (~189Gi raw with 3x Ceph replication) |
+
+## Sync Wave Order
+
+1. **Wave 1**: kube-prometheus-stack (CRDs, Prometheus, Grafana, Alertmanager)
+2. **Wave 2**: Thanos, Loki, Tempo (depend on CRDs and sidecar)
+3. **Wave 3**: Alloy (depends on Loki and Tempo endpoints)
+
+## Security
+
+- **Pod Security Standards**: `monitoring` namespace enforces `baseline` PSS with `restricted` warnings
+- **Loki multi-tenancy**: `auth_enabled: true` with tenant ID `homelab` — all clients must send `X-Scope-OrgID: homelab` header
+- **S3 transport**: Currently HTTP (`insecure: true`) over LAN. **TODO**: Enable TLS on SeaweedFS and update all S3 endpoint configs to remove `insecure: true`
+
+## ServiceMonitors Enabled
+
+The following infrastructure components have ServiceMonitors enabled:
+
+- ingress-nginx (metrics + prometheusRule)
+- MetalLB (serviceMonitor + prometheusRule)
+- rook-ceph operator
+- Ceph cluster (+ PrometheusRules)
+- cert-manager
+
+## Manual Steps
+
+### 1. Encrypt secrets with SOPS
+
+```bash
+cd infrastructure/configs/
+sops -e -i seaweedfs-s3-secret.yaml
+sops -e -i thanos-objstore-secret.yaml
+```
+
+### 2. Verify Ceph StorageClass exists
+
+```bash
+kubectl get sc ceph-block
+```
+
+### 3. Commit and push
+
+```bash
+git add -A
+git commit -m "feat: add Phase 3 observability stack"
+git push
+```
+
+### 4. Monitor deployment
+
+```bash
+# Flux reconciles infrastructure (namespace + secrets)
+flux reconcile kustomization flux-system --with-source
+flux get kustomizations
+
+# ArgoCD syncs applications
+kubectl get applications -n argocd
+kubectl get pods -n monitoring -w
+```
+
+### 5. Get Grafana admin password
+
+```bash
+kubectl get secret kube-prometheus-stack-grafana -n monitoring \
+  -o jsonpath="{.data.admin-password}" | base64 -d
+```
+
+### 6. Verify observability stack
+
+```bash
+# Check all pods are running
+kubectl get pods -n monitoring
+
+# Check Prometheus targets
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090
+# Visit http://localhost:9090/targets
+
+# Check Thanos stores
+kubectl port-forward -n monitoring svc/thanos-query 9090
+# Visit http://localhost:9090/stores
+
+# Check Loki readiness
+kubectl port-forward -n monitoring svc/loki 3100
+# Visit http://localhost:3100/ready
+
+# Check Tempo readiness
+kubectl port-forward -n monitoring svc/tempo 3100
+# Visit http://localhost:3100/ready
+```

--- a/infrastructure/configs/ceph-cluster.yaml
+++ b/infrastructure/configs/ceph-cluster.yaml
@@ -29,8 +29,8 @@ spec:
     toolbox:
       enabled: true
     monitoring:
-      enabled: false
-      createPrometheusRules: false
+      enabled: true
+      createPrometheusRules: true
     cephClusterSpec:
       storage:
         useAllNodes: true

--- a/infrastructure/configs/kustomization.yaml
+++ b/infrastructure/configs/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - default-tls-cert.yaml
   - ipaddressPool.yaml
   - ceph-cluster.yaml
+  - monitoring-ns.yaml
+  - seaweedfs-s3-secret.yaml
+  - thanos-objstore-secret.yaml

--- a/infrastructure/configs/monitoring-ns.yaml
+++ b/infrastructure/configs/monitoring-ns.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted

--- a/infrastructure/configs/seaweedfs-s3-secret.yaml
+++ b/infrastructure/configs/seaweedfs-s3-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: seaweedfs-s3-secret
+    namespace: monitoring
+type: Opaque
+stringData:
+    aws-access-key-id: ENC[AES256_GCM,data:A88J2eT6BjbLgd/+R7Ki8iBwBGs=,iv:hdECu/u4bROvKFGPii3BAfz1HViZRhBDn1Os5fiKLDg=,tag:lp+vEQ7QC2Gbui9qIY8jbA==,type:str]
+    aws-secret-access-key: ENC[AES256_GCM,data:EigFjqJqUH1+JvYAtZYVYi52CiHkDWU6nFhqthqI49qB5ppQFxj/kg==,iv:bQzNMbV5rjLJyN3fYaCS+9uNffOFwrtGwOZ8xszp5YE=,tag:lOOK5fq/cMyTR+YCrlF9Vw==,type:str]
+sops:
+    age:
+        - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2d3Z2dHd4NEh1RjNiMlNT
+            dVpJZmtlY2xRMlJiVUJweGZFdWtuaktOT1UwCjN5dkpucHc1dHMvVGQ1U0lVYzJX
+            bjIwVUlYeHY0UTNJai8zdThwbWNDMWcKLS0tIDBvNVM1NWdQQjUwd1AzM2hnL0dE
+            QkhOYVhwNVFzK3ZWeFVRNS8wcE1LblkKZyoHZlXNcJLVcsfijK/hQ//5Gkccnb1c
+            +3S4czV8TE+97MEpArzWQ/WP9JtnTqDhHrP2uPAfcjVIQn3eguW4vA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-13T20:40:55Z"
+    mac: ENC[AES256_GCM,data:N3uTViTaL6gmAuK0/kKSB2ke9bV7G867wdiBo8GsQWc5Vcb78wwxc/+cTjhKnwKdv3MQuard01yk03AejOVeGPXH9pN35SetfuZSE3WMXZw2ANgfk1C1bczNno/M2vMSt55kO5fC2oi2vjpzV/FVh6UHC4GGQzIkzz5IbaJA/ng=,iv:vGIhcDcvyQTE48LPdzyZXUqcnjNJXgz306eVT6xam+0=,tag:mLoN52B41g8SZpgozqZjJw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/infrastructure/configs/thanos-objstore-secret.yaml
+++ b/infrastructure/configs/thanos-objstore-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: thanos-objstore-secret
+    namespace: monitoring
+type: Opaque
+stringData:
+    objstore.yml: ENC[AES256_GCM,data:sX/NVdCg3Vs2HWjQXsTa3eIbjLwLqxfauf0S9Vo3IxNyNs1QQwgUg93fndGORJNY1+UO/NIr+42wE+GA4Z82m2SDLPoowUD4g9mNm92PnMy7P3Ck2d1ZFnP5SA37yq8EKFYscN6hdnlLgPjbflEx4pyVMVppjaTxZ4VIrCkufqSwe1r29/X3lcDunPeib0oCJggBirgy+mpNCHGYoBmvjHbMYJH2cN+ZXTYvd/35t2jQ7udSu+A9ddzhlLM6XHf1,iv:NmD3mZujsSP9ceHLAdOa3rKgkLkrGicvLY3657gqVjE=,tag:/pQFIXU+BCjIk/VZuL/OGg==,type:str]
+sops:
+    age:
+        - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMMVdkak1nQ1l4RW9UVHYz
+            RUVBV1EwSFp5dCt1R1NnbTJITW5lOUlodlFRCk0xNHJrbkUxUzdsQ09UM3RLT04z
+            SDJ0NVoveXZ1b3plck5IcDF4azZqK2sKLS0tIFB1T21JOGpTQU1pbHJUL3U4bS9u
+            YmNwTnpwUWdhK1ZkR2Y1Y0dSUFRZUlUKVFzLeusM+K7A3qThH0+YftYg6ZIa5wiN
+            leijSEfelPgB8XbS/eJi5tjRXUwmhfXIcVlnN+MptqVzAd+9/xSHBQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-13T20:41:02Z"
+    mac: ENC[AES256_GCM,data:bA0MqWiPeyDO7WBxd43NrP30DB724igHxv3PXV/qLed+Wcltk99CSZWyHXvKz1JLWebHVQfCTKX767qFPXMa/p6dsv73WPe+Z3FHcv7jp+j28jM4xeng9Johc1EOeGM5xwD93zgZj0VYGIBxT1jSsrBVYWA8gTbTsWpkmsi396E=,iv:sBsllngZ8MbShIeq2bDKBieDzdfbgxT6uvmxsxdcxw4=,tag:T4hKALaFOZ8Zmy+s7Fm9yg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/infrastructure/controllers/certmanager/hr.yaml
+++ b/infrastructure/controllers/certmanager/hr.yaml
@@ -16,6 +16,10 @@ spec:
         namespace: cert-manager
       interval: 12h
   values:
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
     installCRDs: true
     replicaCount: 3
     extraArgs:

--- a/infrastructure/controllers/ingress-nginx/hr.yaml
+++ b/infrastructure/controllers/ingress-nginx/hr.yaml
@@ -55,11 +55,11 @@ spec:
       admissionWebhooks:
         enabled: false
       metrics:
-        enabled: false
+        enabled: true
         serviceMonitor:
-          enabled: false
+          enabled: true
         prometheusRule:
-          enabled: false
+          enabled: true
           rules:
             # These are just some sample rules
             - alert: NGINXConfigFailed

--- a/infrastructure/controllers/metallb/hr.yaml
+++ b/infrastructure/controllers/metallb/hr.yaml
@@ -22,6 +22,6 @@ spec:
       ignoreExcludeLB: true
     prometheus:
       serviceMonitor:
-        enabled: false
+        enabled: true
       prometheusRule:
-        enabled: false
+        enabled: true

--- a/infrastructure/controllers/rook-ceph/hr.yaml
+++ b/infrastructure/controllers/rook-ceph/hr.yaml
@@ -28,4 +28,4 @@ spec:
   values:
     # PSP removed in Kubernetes 1.25+ and rook-ceph 1.10+
     monitoring:
-      enabled: false
+      enabled: true


### PR DESCRIPTION
## Summary

- **Infrastructure configs**: Monitoring namespace (with PSS labels), SOPS-encrypted SeaweedFS S3 secrets for Thanos/Loki/Tempo object storage
- **5 ArgoCD Applications** (sync-wave ordered): kube-prometheus-stack (Prometheus + Thanos sidecar + Grafana), Thanos (Query + Store Gateway + Compactor), Loki (SingleBinary, multi-tenant auth), Tempo (monolithic, OTLP receivers), Alloy (DaemonSet log/trace collector)
- **ServiceMonitors enabled** on ingress-nginx, MetalLB, rook-ceph, Ceph cluster, and cert-manager
- **Deployment documentation** with architecture diagram, endpoints, retention policies, storage requirements, and verification steps

### Architecture

```
Grafana (grafana.sharmamohit.com)
  ├── Thanos Query → Store Gateway + Prometheus Sidecar → SeaweedFS S3
  ├── Loki (SingleBinary, tenant: homelab) → SeaweedFS S3
  └── Tempo (monolithic, OTLP) → SeaweedFS S3

Alloy DaemonSet → Logs to Loki, Traces to Tempo
```

### Storage
- **S3 backend**: SeaweedFS on TrueNAS (buckets: thanos-metrics, loki-chunks, loki-ruler, tempo-traces)
- **Ceph PVCs**: 63Gi total (Prometheus 20Gi, Thanos 20Gi, Loki 10Gi, Tempo 10Gi, Alertmanager 1Gi, Grafana 2Gi)

### Security
- Pod Security Standards: baseline enforce, restricted warn
- Loki multi-tenancy with `auth_enabled: true` (tenant: homelab)
- All secrets SOPS-encrypted with age
- S3 TLS documented as TODO (currently HTTP over LAN)

## Test plan

- [ ] Verify Flux reconciles infrastructure configs (`flux get kustomizations`)
- [ ] Verify ArgoCD syncs all 5 applications (`kubectl get applications -n argocd`)
- [ ] Verify all pods are running in monitoring namespace
- [ ] Verify Prometheus targets are up (port-forward to :9090/targets)
- [ ] Verify Thanos stores are connected (port-forward to thanos-query :9090/stores)
- [ ] Verify Loki readiness (port-forward to :3100/ready)
- [ ] Verify Tempo readiness (port-forward to :3100/ready)
- [ ] Verify Grafana datasources are working at grafana.sharmamohit.com
- [ ] Verify ServiceMonitors appear as Prometheus targets for ingress-nginx, MetalLB, rook-ceph, cert-manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)