### PR TITLE
feat: enable ServiceMonitors and fix observability stack

### DIFF
--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -136,6 +136,17 @@ spec:
               memory: 128Mi
             limits:
               memory: 256Mi
+  # ArgoCD v2.14 doesn't recognize .status.terminatingReplicas added in K8s 1.31+
+  # Remove once ArgoCD is upgraded to a version with updated schemas
+  ignoreDifferences:
+    - group: apps
+      kind: DaemonSet
+      jqPathExpressions:
+        - .status.terminatingReplicas
+    - group: apps
+      kind: StatefulSet
+      jqPathExpressions:
+        - .status.terminatingReplicas
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
@@ -146,3 +157,4 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true

--- a/infrastructure/configs/monitoring-ns.yaml
+++ b/infrastructure/configs/monitoring-ns.yaml
@@ -4,5 +4,6 @@ kind: Namespace
 metadata:
   name: monitoring
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: restricted
+    # privileged required: node-exporter needs hostNetwork, hostPID, hostPath
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: baseline

--- a/infrastructure/controllers/certmanager/hr.yaml
+++ b/infrastructure/controllers/certmanager/hr.yaml
@@ -17,6 +17,10 @@ spec:
       interval: 12h
   values:
     installCRDs: true
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
     replicaCount: 3
     extraArgs:
       - "--dns01-recursive-nameservers=192.168.11.1:53,9.9.9.9:53"

--- a/infrastructure/controllers/ingress-nginx/hr.yaml
+++ b/infrastructure/controllers/ingress-nginx/hr.yaml
@@ -57,9 +57,9 @@ spec:
       metrics:
         enabled: true
         serviceMonitor:
-          enabled: false
+          enabled: true
         prometheusRule:
-          enabled: false
+          enabled: true
           rules:
             # These are just some sample rules
             - alert: NGINXConfigFailed

--- a/infrastructure/controllers/metallb/hr.yaml
+++ b/infrastructure/controllers/metallb/hr.yaml
@@ -20,3 +20,11 @@ spec:
       frr:
         enabled: false
       ignoreExcludeLB: true
+    prometheus:
+      rbacPrometheus: true
+      serviceAccount: kube-prometheus-stack-prometheus
+      namespace: monitoring
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true


### PR DESCRIPTION
## Summary
- **Re-enable ServiceMonitors** on ingress-nginx, metallb, and cert-manager infrastructure controllers (rook-ceph was already done)
- **Fix ArgoCD ComparisonError** on kube-prometheus-stack — K8s v1.35 added `.status.terminatingReplicas` to DaemonSet/StatefulSet that ArgoCD v2.14 doesn't understand. Added `ignoreDifferences` + `RespectIgnoreDifferences=true`
- **Fix PodSecurity** on monitoring namespace — upgraded from `baseline` to `privileged` so node-exporter can use hostNetwork/hostPID/hostPath (currently 0/3 pods scheduled)

## Issues Found During Investigation
- **Prometheus CR is missing** — `kubectl get prometheus -A` returns empty. ArgoCD shows it as `health=Missing`. Once the ComparisonError is resolved, ArgoCD should recreate it
- **No Thanos pods** — Thanos sidecar runs inside Prometheus pod, which doesn't exist yet. Will come up with Prometheus
- **Node-exporter blocked** — PodSecurity `baseline` rejects hostNetwork/hostPID/hostPath volumes

## Test plan
- [ ] Merge and let Flux reconcile the infrastructure controller changes
- [ ] Verify ArgoCD kube-prometheus-stack Application transitions from `Unknown` to `Synced`
- [ ] Confirm Prometheus pod + Thanos sidecar come up in monitoring namespace
- [ ] Confirm node-exporter DaemonSet schedules pods (3/3)
- [ ] Verify new ServiceMonitors appear: `kubectl get servicemonitors -A`
- [ ] Check Prometheus targets page for ingress-nginx, metallb, cert-manager scrape targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)