### PR TITLE
fix: resolve ArgoCD sync failures for kube-prometheus-stack

### DIFF
--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -42,8 +42,9 @@ spec:
                 memory: 4Gi
             thanos:
               objectStorageConfig:
-                name: thanos-objstore-secret
-                key: objstore.yml
+                existingSecret:
+                  name: thanos-objstore-secret
+                  key: objstore.yml
           thanosService:
             enabled: true
           thanosServiceMonitor:
@@ -136,17 +137,6 @@ spec:
               memory: 128Mi
             limits:
               memory: 256Mi
-  # ArgoCD v2.14 doesn't recognize .status.terminatingReplicas added in K8s 1.31+
-  # Remove once ArgoCD is upgraded to a version with updated schemas
-  ignoreDifferences:
-    - group: apps
-      kind: DaemonSet
-      jqPathExpressions:
-        - .status.terminatingReplicas
-    - group: apps
-      kind: StatefulSet
-      jqPathExpressions:
-        - .status.terminatingReplicas
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
@@ -157,4 +147,3 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
-      - RespectIgnoreDifferences=true

--- a/apps/base/argocd/argocd-hr.yaml
+++ b/apps/base/argocd/argocd-hr.yaml
@@ -22,8 +22,13 @@ spec:
     global:
       domain: argocd.sharmamohit.com
     configs:
-      exec.enabled: true
-      statusbadge.enabled: true
+      cm:
+        exec.enabled: "true"
+        statusbadge.enabled: "true"
+        # Skip status fields during resource comparison to avoid schema mismatches
+        # between K8s API version and ArgoCD's internal schemas
+        resource.compareoptions: |
+          ignoreResourceStatusField: all
     server:
       ingress: 
         enabled: true


### PR DESCRIPTION
## Summary
- **ArgoCD ComparisonError**: Added `resource.compareoptions: ignoreResourceStatusField: all` to `argocd-cm` — fixes the K8s v1.35 `.status.terminatingReplicas` schema mismatch that was blocking all syncs. Also fixes the `configs` structure in the ArgoCD HelmRelease to use the correct `configs.cm` path for chart v7.x.
- **Prometheus CR creation failure**: Chart v81.x changed the Thanos config API — `objectStorageConfig` now requires `existingSecret` sub-key instead of `name`/`key` directly. This was causing `spec.thanos: null` rendering, making the Prometheus CR invalid.
- **Removed** per-app `ignoreDifferences` workaround (superseded by global `compareoptions`)

## Context
After merging PR #21, ArgoCD could compare resources again (namespace PodSecurity fixed, ComparisonError partially resolved). But the Prometheus CR still failed to apply because:
1. The `resource.compareoptions` setting was needed at the argocd-cm level (not just `ignoreDifferences` per-app)
2. The Thanos objectStorageConfig API changed in chart v81.x

The argocd-cm was already patched live for immediate effect. This PR persists the fix in git.

## Test plan
- [ ] Verify ArgoCD kube-prometheus-stack Application syncs to `Synced`/`Healthy`
- [ ] Confirm Prometheus StatefulSet + pod created in monitoring namespace
- [ ] Confirm Thanos sidecar container running inside Prometheus pod
- [ ] Verify node-exporter DaemonSet has 3/3 pods running

🤖 Generated with [Claude Code](https://claude.com/claude-code)