### PR TITLE
fix: switch Thanos chart to OCI registry

### DIFF
--- a/apps/argocd-apps/apps/thanos.yaml
+++ b/apps/argocd-apps/apps/thanos.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.bitnami.com/bitnami
+    # Bitnami migrated to OCI-only; legacy HTTP repo no longer serves charts
+    repoURL: registry-1.docker.io/bitnamicharts
     chart: thanos
     targetRevision: "17.x"
     helm:


### PR DESCRIPTION
## Summary
- Bitnami migrated to OCI-only distribution — the legacy HTTP repo (`charts.bitnami.com/bitnami`) no longer serves charts
- ArgoCD was failing with `invalid_reference: invalid tag` when trying to pull the Thanos chart
- Switched `repoURL` to `registry-1.docker.io/bitnamicharts` (OCI registry)

## Root cause
This is why Grafana shows no metrics — Thanos Query never deployed, and Grafana's default datasource points to `thanos-query.monitoring.svc:9090`.

## Test plan
- [ ] Verify Thanos Application syncs in ArgoCD
- [ ] Confirm thanos-query, storegateway, and compactor pods come up
- [ ] Check Grafana can query metrics via the Thanos datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)