### PR TITLE
fix: use official Thanos image (Bitnami removed from Docker Hub)

### DIFF
--- a/apps/argocd-apps/apps/thanos.yaml
+++ b/apps/argocd-apps/apps/thanos.yaml
@@ -16,6 +16,15 @@ spec:
     targetRevision: "17.x"
     helm:
       valuesObject:
+        # Bitnami removed free images from Docker Hub (Aug 2025)
+        # Use official Thanos image instead
+        global:
+          security:
+            allowInsecureImages: true
+        image:
+          registry: quay.io
+          repository: thanos/thanos
+          tag: v0.41.0
         existingObjstoreSecret: thanos-objstore-secret
         query:
           enabled: true


### PR DESCRIPTION
## Summary
- Bitnami [removed free Docker images](https://github.com/bitnami/charts/issues/35164) from Docker Hub as of Aug 2025
- The `docker.io/bitnami/thanos:0.39.2-debian-12-r2` image no longer exists (0 tags on Docker Hub)
- Overrides the Bitnami chart to use `quay.io/thanos/thanos:v0.41.0` (official image, same version as the Thanos sidecar in the Prometheus pod)
- Sets `global.security.allowInsecureImages: true` (required by Bitnami chart to allow non-Bitnami images)

## Test plan
- [ ] Verify thanos-query, storegateway, compactor pods start successfully
- [ ] Check Grafana can query metrics via the Thanos datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)