### PR TITLE
fix: correct Tempo datasource port from 3100 to 3200

### DIFF
--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -85,7 +85,7 @@ spec:
             - name: Tempo
               type: tempo
               uid: tempo
-              url: http://tempo.monitoring.svc:3100
+              url: http://tempo.monitoring.svc:3200
               access: proxy
               jsonData:
                 tracesToLogs:


### PR DESCRIPTION
## Summary
- Tempo HTTP API listens on port **3200**, not 3100
- Port 3100 is Loki's port — the Tempo datasource was pointing at Loki by mistake
- This is why Grafana's Explore > Traces shows "failed to connect to tempo"

## Test plan
- [ ] Open Grafana > Explore, select Tempo datasource, run a query — should connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)