### PR TITLE
refactor: organize ArgoCD apps into monitoring project

### DIFF
--- a/apps/argocd-apps/apps/alloy.yaml
+++ b/apps/argocd-apps/apps/alloy.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: alloy

--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack

--- a/apps/argocd-apps/apps/loki.yaml
+++ b/apps/argocd-apps/apps/loki.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: loki

--- a/apps/argocd-apps/apps/project-monitoring.yaml
+++ b/apps/argocd-apps/apps/project-monitoring.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: monitoring
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Observability stack (Prometheus, Thanos, Loki, Tempo, Alloy)
+  sourceRepos:
+    - https://prometheus-community.github.io/helm-charts
+    - https://grafana.github.io/helm-charts
+    - registry-1.docker.io/bitnamicharts
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: monitoring
+    # kube-prometheus-stack creates ServiceMonitors in kube-system
+    - server: https://kubernetes.default.svc
+      namespace: kube-system
+  clusterResourceWhitelist:
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/apps/argocd-apps/apps/tempo.yaml
+++ b/apps/argocd-apps/apps/tempo.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: tempo

--- a/apps/argocd-apps/apps/thanos.yaml
+++ b/apps/argocd-apps/apps/thanos.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     # Bitnami migrated to OCI-only; legacy HTTP repo no longer serves charts
     repoURL: registry-1.docker.io/bitnamicharts

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -9,7 +9,7 @@ Full metrics/logs/traces observability stack deployed in the `monitoring` namesp
 | Component | Chart | Version | Purpose |
 |-----------|-------|---------|---------|
 | kube-prometheus-stack | prometheus-community | 81.x | Prometheus, Grafana, Alertmanager, node-exporter, kube-state-metrics |
-| Thanos | bitnami/thanos | 17.x | Long-term metrics (Query, Store Gateway, Compactor) |
+| Thanos | bitnami/thanos (OCI: `registry-1.docker.io/bitnamicharts`) | 17.x | Long-term metrics (Query, Store Gateway, Compactor) |
 | Loki | grafana/loki | 6.x | Log aggregation (SingleBinary mode) |
 | Tempo | grafana/tempo | 1.x | Distributed tracing (monolithic mode) |
 | Alloy | grafana/alloy | 1.x | Log collection + trace forwarding (DaemonSet) |
@@ -152,7 +152,7 @@ Grafana
 | Prometheus | http://kube-prometheus-stack-prometheus.monitoring.svc:9090 |
 | Thanos Query | http://thanos-query.monitoring.svc:9090 |
 | Loki | http://loki.monitoring.svc:3100 |
-| Tempo HTTP | http://tempo.monitoring.svc:3100 |
+| Tempo HTTP | http://tempo.monitoring.svc:3200 |
 | Tempo OTLP gRPC | tempo.monitoring.svc:4317 |
 | Tempo OTLP HTTP | http://tempo.monitoring.svc:4318 |
 | Alertmanager | http://kube-prometheus-stack-alertmanager.monitoring.svc:9093 |
@@ -208,7 +208,7 @@ Two SOPS-encrypted secrets in `infrastructure/configs/`:
 
 ## Security
 
-- **Pod Security Standards**: `monitoring` namespace enforces `baseline` PSS with `restricted` warnings
+- **Pod Security Standards**: `monitoring` namespace enforces `privileged` PSS (required by node-exporter: hostNetwork, hostPID, hostPath) with `baseline` warnings
 - **Loki multi-tenancy**: `auth_enabled: true` with tenant ID `homelab` — all clients must send `X-Scope-OrgID: homelab` header
 - **S3 transport**: Currently HTTP (`insecure: true`) over LAN. **TODO**: Enable TLS on SeaweedFS and update all S3 endpoint configs to remove `insecure: true`
 
@@ -284,6 +284,6 @@ kubectl port-forward -n monitoring svc/loki 3100
 # Visit http://localhost:3100/ready
 
 # Check Tempo readiness
-kubectl port-forward -n monitoring svc/tempo 3100
-# Visit http://localhost:3100/ready
+kubectl port-forward -n monitoring svc/tempo 3200
+# Visit http://localhost:3200/ready
 ```


### PR DESCRIPTION
## Summary
- Creates an `AppProject` named **monitoring** to group all observability apps
- Moves 5 apps from `default` → `monitoring` project: kube-prometheus-stack, thanos, loki, tempo, alloy
- `default` project now only has: root-app, podinfo

## AppProject scope
- **Sources**: prometheus-community, grafana, bitnami OCI registries
- **Destinations**: `monitoring` and `kube-system` namespaces (kube-prometheus-stack creates ServiceMonitors in kube-system)
- **Cluster resources**: ClusterRole, ClusterRoleBinding, CRDs, Webhooks
- **Sync-wave**: `-1` (created before apps that reference it)

## Test plan
- [ ] Verify AppProject created: `kubectl get appproject -n argocd`
- [ ] Verify all 5 monitoring apps show `project: monitoring` in ArgoCD UI
- [ ] Confirm apps remain Synced/Healthy after project change
- [ ] Verify podinfo and root-app still in `default` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)