### PR TITLE
feat: add external write endpoints for Docker host monitoring

### DIFF
--- a/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -17,6 +17,7 @@ spec:
       valuesObject:
         prometheus:
           prometheusSpec:
+            enableRemoteWriteReceiver: true
             retention: 3d
             retentionSize: 15GB
             storageSpec:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -170,6 +170,7 @@ Authenticated Ingress endpoints allow external Docker hosts to push metrics and 
 
 **Ingress annotations** (both):
 - `auth-type: basic` + `auth-secret: monitoring-basic-auth`
+- `force-ssl-redirect: true` (ensure credentials are never sent over plain HTTP)
 - `proxy-body-size: 10m` (accommodate metric/log batches)
 - `proxy-read-timeout: 300` (allow slow remote-write flushes)
 - No TLS section — wildcard cert handled by ingress-nginx `default-ssl-certificate`
@@ -203,7 +204,7 @@ SOPS-encrypted secrets in `infrastructure/configs/`:
 | `thanos-objstore-secret` | monitoring | `objstore.yml` | Prometheus Thanos sidecar, Thanos components |
 | `monitoring-basic-auth` | monitoring | `auth` (htpasswd) | Ingress basic auth for external write endpoints |
 
-**Credential rotation note**: Both secrets contain the same SeaweedFS observability IAM credentials. When rotating credentials, update **both** `seaweedfs-s3-secret` and `thanos-objstore-secret`, then re-encrypt with SOPS.
+**Credential rotation note**: The `seaweedfs-s3-secret` and `thanos-objstore-secret` both contain the same SeaweedFS observability IAM credentials. When rotating credentials, update **both** secrets, then re-encrypt with SOPS.
 
 ## Retention Policy
 

--- a/infrastructure/configs/kustomization.yaml
+++ b/infrastructure/configs/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - monitoring-ns.yaml
   - seaweedfs-s3-secret.yaml
   - thanos-objstore-secret.yaml
+  - monitoring-basic-auth-secret.yaml
+  - monitoring-ingress.yaml

--- a/infrastructure/configs/monitoring-basic-auth-secret.yaml
+++ b/infrastructure/configs/monitoring-basic-auth-secret.yaml
@@ -5,19 +5,21 @@ metadata:
     namespace: monitoring
 type: Opaque
 stringData:
-    auth: ENC[AES256_GCM,data:IBlcLCiuyVkyHvH3eZnhkUZVOGMMJXmDxqi96KjyuxmlNF4=,iv:Z8J1/e0Q3Uqyk0io/XxBE570CwDjMxYwXhUMZF7G5Ps=,tag:e4LFxvGZ5KYdFZiy9xrgLw==,type:str]
+    auth: ENC[AES256_GCM,data:kpT94Kn9/pC/Oh/n7DlANt/v/ogUcUc8eulBSKVA6/CsvJT3ExVf8IaYNyHshLusQqzHlJVe/R3ta22Nu6jjQIdS,iv:ZbwSEfZt/Rfc0XyqTy/oInw+eL9PNx6wiht6zMHTJOU=,tag:M2hAFGBvBWoSIXXjOfVnTw==,type:str]
+    username: ENC[AES256_GCM,data:nNrTVs4=,iv:oCHaBV5jo+GbYKPlacaw0aBSwuwHTdjLSZsfT9NyQTU=,tag:3Gh4O2Eew4zm+aU2EzANLw==,type:str]
+    password: ENC[AES256_GCM,data:YBTWfchoisT9XIkbQ60NETpE/nZqQ4cY/2LWoQvZJWWVkxnaYyl625AMfQ==,iv:VqcqPwnD30GHbvkqVG+tNCRm/VCAeArYdt/QzXX1PbY=,tag:kM6eoRjP6UvtwUyAr9JTRw==,type:str]
 sops:
     age:
         - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2QjlxWEtETzBXa3U4b2NY
-            a1g5emYxWk96cy85ejR2dmpTYUVvc2UweGtVClRxMzRGNnkrTHNLQ1FzWUkrdnp2
-            aW5UNzNMK3RmaXJiWENVcjdKTHVObFUKLS0tICtqenpaYzJxaFZHSmVYU084cU5X
-            aE5yRzdoYWoyOUZGS245K21CVm40T28KKUbhxoLYMljz9E1Gx1xxz0CD15cA7jXV
-            pCj1fVodYigUqTN5BbwR8jqGlBcXsPtw8oeOIM91LemNJYDUGz1G3Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvT3lybVZpSGh5c0VzbzRo
+            RnVCZUlWcU9ta1V5RXl6dkFocHV3akIrQ2xFCmdKYk03MytFdnFNSlJNeXg3ekpi
+            VWdyTWpTNm9FN3VpWUNGSFRsUzJnN0kKLS0tIDhjcUp1eDNHbmh5bFd4Ykg1YjE3
+            L1dqTCsvcmR0NjBIc21GSGpVVXlSZnMKPIF6726d2q9P5MlhVntr9SagJnO5UJ5H
+            6L3N3FFRNh2OSdnA2JWHvP4XGwEixgIO7cE3069LoLuuBr758AAMhg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-14T07:40:17Z"
-    mac: ENC[AES256_GCM,data:DaUSG1P2D6bZQQh2dHZm1Nw/+PKBNZ5Zs1uoWva45S3hp+CtAi/fRj5s+rW8aUlsxOE0DSAUQ3T2qPRwc2Shfy4+vP3o8R0NE03ijnwoJZObDCJXN5rKQADba9mvnL9O26Hp/RMv05KVhhHJsxPbqLpNSwLHZBTYsgvfwT9Y7qk=,iv:0JKTc3kt5xkR362r0DFjLrWYRF7kBCEl0iFoGXechIk=,tag:MNXJovimN5Oluqmh7LbTcw==,type:str]
+    lastmodified: "2026-02-14T07:55:10Z"
+    mac: ENC[AES256_GCM,data:CA8A718FZFsor17Geg+j6Qhez9QlDh7o75mma/uesN3eQkUEGu3CZOeIivzqMpQyfcTvwHCwaVJlOW8MQSoxiwNdKUNm/kkcAXcXe72qvANS3YMwBzGifWfXUBU5+De0nCx26+X3zduP3mImpR/jYxpgj0GLO0zjrHG5nbXRxwY=,iv:4fUVMMD/CUDxqD4+Qvp/CGCtDKJUdzADo40ZYvCEnQQ=,tag:jPhyZEfpNaN+RPUCoJ6z0Q==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.11.0

--- a/infrastructure/configs/monitoring-basic-auth-secret.yaml
+++ b/infrastructure/configs/monitoring-basic-auth-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: monitoring-basic-auth
+    namespace: monitoring
+type: Opaque
+stringData:
+    auth: ENC[AES256_GCM,data:IBlcLCiuyVkyHvH3eZnhkUZVOGMMJXmDxqi96KjyuxmlNF4=,iv:Z8J1/e0Q3Uqyk0io/XxBE570CwDjMxYwXhUMZF7G5Ps=,tag:e4LFxvGZ5KYdFZiy9xrgLw==,type:str]
+sops:
+    age:
+        - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2QjlxWEtETzBXa3U4b2NY
+            a1g5emYxWk96cy85ejR2dmpTYUVvc2UweGtVClRxMzRGNnkrTHNLQ1FzWUkrdnp2
+            aW5UNzNMK3RmaXJiWENVcjdKTHVObFUKLS0tICtqenpaYzJxaFZHSmVYU084cU5X
+            aE5yRzdoYWoyOUZGS245K21CVm40T28KKUbhxoLYMljz9E1Gx1xxz0CD15cA7jXV
+            pCj1fVodYigUqTN5BbwR8jqGlBcXsPtw8oeOIM91LemNJYDUGz1G3Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-14T07:40:17Z"
+    mac: ENC[AES256_GCM,data:DaUSG1P2D6bZQQh2dHZm1Nw/+PKBNZ5Zs1uoWva45S3hp+CtAi/fRj5s+rW8aUlsxOE0DSAUQ3T2qPRwc2Shfy4+vP3o8R0NE03ijnwoJZObDCJXN5rKQADba9mvnL9O26Hp/RMv05KVhhHJsxPbqLpNSwLHZBTYsgvfwT9Y7qk=,iv:0JKTc3kt5xkR362r0DFjLrWYRF7kBCEl0iFoGXechIk=,tag:MNXJovimN5Oluqmh7LbTcw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/infrastructure/configs/monitoring-ingress.yaml
+++ b/infrastructure/configs/monitoring-ingress.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-remote-write
+  namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: prometheus.sharmamohit.com
+      http:
+        paths:
+          - path: /api/v1/write
+            pathType: Exact
+            backend:
+              service:
+                name: kube-prometheus-stack-prometheus
+                port:
+                  number: 9090
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: loki-push
+  namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: loki.sharmamohit.com
+      http:
+        paths:
+          - path: /loki/api/v1/push
+            pathType: Exact
+            backend:
+              service:
+                name: loki
+                port:
+                  number: 3100

--- a/infrastructure/configs/monitoring-ingress.yaml
+++ b/infrastructure/configs/monitoring-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:
@@ -31,6 +32,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:


### PR DESCRIPTION
## Summary
- Enable Prometheus remote-write receiver (`enableRemoteWriteReceiver: true`) to accept metrics from external hosts
- Create SOPS-encrypted basic-auth secret for Ingress authentication
- Create two Ingress resources with `pathType: Exact` to expose write-only endpoints:
  - `prometheus.sharmamohit.com/api/v1/write` → Prometheus remote-write
  - `loki.sharmamohit.com/loki/api/v1/push` → Loki push API
- Update monitoring docs with External Write Endpoints section and secrets table

## Context
Phase 4 of observability deployment. This PR sets up the K8s-side infrastructure to receive metrics and logs from 6 external Docker hosts running Grafana Alloy (PR #2 deploys the Alloy compose stack).

## Manual Steps Required
1. Generate htpasswd content and update the secret before encrypting:
   ```bash
   htpasswd -nbB alloy <password>
   # Update stringData.auth in infrastructure/configs/monitoring-basic-auth-secret.yaml
   sops -e -i infrastructure/configs/monitoring-basic-auth-secret.yaml
   ```

## Test plan
- [ ] Verify Flux reconciles the new secret and Ingress resources
- [ ] Verify ArgoCD syncs the updated kube-prometheus-stack with remote-write enabled
- [ ] Test: `curl -u alloy:<pw> -X POST https://prometheus.sharmamohit.com/api/v1/write` returns 400 (not 405)
- [ ] Test: `curl -u alloy:<pw> -H "X-Scope-OrgID: homelab" -X POST https://loki.sharmamohit.com/loki/api/v1/push` returns 400/204
- [ ] Test: `curl -X POST https://prometheus.sharmamohit.com/api/v1/write` returns 401 (unauthenticated blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)