### PR TITLE
feat: add racknerd-aegis VPS to Komodo management

### DIFF
--- a/docker/komodo-resources/servers.toml
+++ b/docker/komodo-resources/servers.toml
@@ -51,3 +51,12 @@ tags = ["bare-metal", "storage"]
 address = "https://seaweedfs.sharmamohit.com:8120"
 region = "HomeLab"
 enabled = true
+
+[[server]]
+name = "racknerd-aegis"
+description = "RackNerd VPS — Pangolin gateway, CrowdSec, identity providers"
+tags = ["vps", "gateway"]
+[server.config]
+address = "https://periphery.private.sharmamohit.com:8120"
+region = "VPS"
+enabled = true


### PR DESCRIPTION
## Summary
- Register RackNerd VPS (23.94.73.98) as a Komodo-managed server
- Periphery reachable via Pangolin private resource tunnel (`periphery.private.sharmamohit.com:8120`) — no internet exposure
- Includes deployment plan document (`docs/racknerd-aegis-plan.md`)

## Context
Phase 2f of the racknerd-aegis deployment plan. Periphery is already running on the VPS, Newt tunnel is established, and the Komodo Machine Client on LXC 200 has verified connectivity.

## Test plan
- [ ] `km execute sync 'mohitsharma44/homeops'` picks up new server
- [ ] `km list servers -a` shows racknerd-aegis as healthy
- [ ] Komodo UI shows VPS containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)