### PR TITLE
fix: bind-mount resolv.conf into Komodo Core

### DIFF
--- a/docker/stacks/komodo/core/compose.yaml
+++ b/docker/stacks/komodo/core/compose.yaml
@@ -60,6 +60,7 @@ services:
       TZ: America/Vancouver
     volumes:
       - /etc/komodo/backups:/backups
+      - /etc/resolv.conf:/etc/resolv.conf:ro
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary
- Bind-mount `/etc/resolv.conf:ro` into Komodo Core container
- Fixes Docker DNS caching issue where Core can't resolve Pangolin private resource hostnames

## Context
Docker caches the host's DNS servers at daemon startup. When pangolin-cli overwrites `/etc/resolv.conf` to `100.96.128.1` (Pangolin DNS proxy) after boot, Core containers still use the stale cached DNS (`192.168.11.1`). This prevents Core from resolving `periphery.private.sharmamohit.com` to reach the VPS Periphery.

Bind-mounting resolv.conf bypasses Docker's DNS caching entirely — the container reads the file directly.

## Test plan
- [ ] `km execute deploy-stack komodo-core` succeeds
- [ ] `km list servers -a` shows racknerd-aegis as `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)