### PR TITLE
fix: replace resolv.conf bind-mount with dns directive

### DIFF
--- a/docker/stacks/komodo/core/compose.yaml
+++ b/docker/stacks/komodo/core/compose.yaml
@@ -58,9 +58,10 @@ services:
       KOMODO_MONITORING_INTERVAL: "15-sec"
       KOMODO_RESOURCE_POLL_INTERVAL: "1-hr"
       TZ: America/Vancouver
+    dns:
+      - 100.96.128.1
     volumes:
       - /etc/komodo/backups:/backups
-      - /etc/resolv.conf:/etc/resolv.conf:ro
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary
- Replace `/etc/resolv.conf` bind-mount with `dns: [100.96.128.1]` directive on Komodo Core
- Fixes PR #33 which broke Docker internal DNS (Core couldn't resolve `ferretdb:27017`)

## Why
The bind-mount replaced Docker's generated resolv.conf (with `127.0.0.11` internal resolver) with the host's Pangolin DNS-only resolv.conf. This broke container-to-container name resolution.

The `dns` directive tells Docker's embedded DNS where to forward **external** queries, while preserving internal container name resolution via `127.0.0.11`.

## Test plan
- [ ] `km execute deploy-stack komodo-core` — Core starts, connects to ferretdb
- [ ] `km list servers -a` — racknerd-aegis shows `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)