### PR TITLE
fix: use host networking for Komodo Core

### DIFF
--- a/docker/stacks/komodo/core/compose.yaml
+++ b/docker/stacks/komodo/core/compose.yaml
@@ -28,6 +28,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    ports:
+      - "127.0.0.1:27017:27017"
     volumes:
       - ferretdb-state:/state
     environment:
@@ -40,14 +42,13 @@ services:
     restart: unless-stopped
     security_opt:
       - apparmor:unconfined
+    network_mode: host
     depends_on:
       ferretdb:
         condition: service_healthy
     env_file: .env
-    ports:
-      - 9120:9120
     environment:
-      KOMODO_DATABASE_ADDRESS: ferretdb:27017
+      KOMODO_DATABASE_ADDRESS: 127.0.0.1:27017
       KOMODO_DATABASE_USERNAME: ${KOMODO_DB_USERNAME}
       KOMODO_DATABASE_PASSWORD: ${KOMODO_DB_PASSWORD}
       KOMODO_HOST: https://komodo.sharmamohit.com
@@ -58,8 +59,6 @@ services:
       KOMODO_MONITORING_INTERVAL: "15-sec"
       KOMODO_RESOURCE_POLL_INTERVAL: "1-hr"
       TZ: America/Vancouver
-    dns:
-      - 100.96.128.1
     volumes:
       - /etc/komodo/backups:/backups
 


### PR DESCRIPTION
## Summary
- Switch Komodo Core to `network_mode: host` so it reads the host's resolv.conf directly
- Removes hardcoded Pangolin DNS proxy IP (`dns: [100.96.128.1]`) from PR #34
- FerretDB publishes port on `127.0.0.1:27017` for Core to reach it
- Core connects to `127.0.0.1:27017` instead of `ferretdb:27017`

## Why
The Pangolin DNS proxy IP (100.96.128.1) is internally assigned by Pangolin and could change on upgrades. Host networking lets Core use whatever DNS the host has, with no hardcoded IPs.

## Test plan
- [ ] `km execute sync && km execute deploy-stack komodo-core`
- [ ] `km list servers -a` — all 7 servers `ok`
- [ ] `km container -a | grep racknerd` — VPS containers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)