### PR TITLE
fix: CrowdSec Go template escaping in Traefik dynamic config

### DIFF
--- a/docker/stacks/racknerd-aegis/aegis-gateway/config/dynamic/crowdsec.yml
+++ b/docker/stacks/racknerd-aegis/aegis-gateway/config/dynamic/crowdsec.yml
@@ -10,7 +10,7 @@ http:
           crowdsecLapiScheme: http
           crowdsecLapiHost: aegis-crowdsec:8080
           # API key must match BOUNCER_KEY_traefik in CrowdSec container
-          crowdsecLapiKey: "{{ env \"CROWDSEC_BOUNCER_KEY\" }}"
+          crowdsecLapiKey: "{{ env "CROWDSEC_BOUNCER_KEY" }}"
           # Use streaming mode for better performance
           # Decisions cached locally, updated every 60s
           crowdsecMode: stream


### PR DESCRIPTION
## Summary
- Remove backslash escaping from Go template `{{ env "CROWDSEC_BOUNCER_KEY" }}` in CrowdSec bouncer middleware config
- Traefik evaluates Go templates before YAML parsing, so inner quotes must not be escaped

## Context
Discovered during Phase 5 migration — outer Traefik failed to load the CrowdSec middleware, causing it to serve a default TLS certificate instead of the Let's Encrypt one.

## Test plan
- [x] Verified fix on VPS — Traefik loads CrowdSec middleware without errors
- [x] CrowdSec bouncer connects to LAPI successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)