### PR TITLE
feat: K8s Newt site for Pangolin private resource tunneling

### DIFF
--- a/kubernetes/apps/argocd-apps/apps/newt.yaml
+++ b/kubernetes/apps/argocd-apps/apps/newt.yaml
@@ -13,12 +13,19 @@ spec:
     targetRevision: "1.1.0"
     helm:
       valuesObject:
-        auth:
-          existingSecretName: newt-credentials
-          keys:
-            endpointKey: PANGOLIN_ENDPOINT
-            idKey: NEWT_ID
-            secretKey: NEWT_SECRET
+        global:
+          image:
+            tag: "1.9.0"
+        newtInstances:
+          - name: homelab-k8s
+            auth:
+              existingSecretName: newt-credentials
+              keys:
+                endpointKey: PANGOLIN_ENDPOINT
+                idKey: NEWT_ID
+                secretKey: NEWT_SECRET
+            service:
+              enabled: false
   destination:
     server: https://kubernetes.default.svc
     namespace: pangolin

--- a/kubernetes/apps/argocd-apps/apps/newt.yaml
+++ b/kubernetes/apps/argocd-apps/apps/newt.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: newt
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.fossorial.io
+    chart: newt
+    targetRevision: "1.1.0"
+    helm:
+      valuesObject:
+        auth:
+          existingSecretName: newt-credentials
+          keys:
+            endpointKey: PANGOLIN_ENDPOINT
+            idKey: NEWT_ID
+            secretKey: NEWT_SECRET
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pangolin
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true

--- a/kubernetes/infrastructure/configs/kustomization.yaml
+++ b/kubernetes/infrastructure/configs/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - thanos-objstore-secret.yaml
   - monitoring-basic-auth-secret.yaml
   - monitoring-ingress.yaml
+  - pangolin-ns.yaml
+  - newt-credentials-secret.yaml

--- a/kubernetes/infrastructure/configs/newt-credentials-secret.yaml
+++ b/kubernetes/infrastructure/configs/newt-credentials-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: newt-credentials
+    namespace: pangolin
+type: Opaque
+stringData:
+    PANGOLIN_ENDPOINT: ENC[AES256_GCM,data:/ROoe9tb1kxN4ZCzG/sgGo6DNlCujVhhs1PI6OX9+CvMFHP+CQQ=,iv:DLh1xCaH3w8tRca5R1+pJq2KLAjJ5/9iX9vvoruNe60=,tag:mIIBnlqyWjHQipnDFmkTeg==,type:str]
+    NEWT_ID: ENC[AES256_GCM,data:SQP6AMSGdSI/5qgf18R+,iv:U9jFHYS9q5yQIjsTSCmS8GMHqZL1Ay6FJ4Xfwu4w83c=,tag:fWdzPsU2xxpNe7FggmbHJg==,type:str]
+    NEWT_SECRET: ENC[AES256_GCM,data:I/R/qaPEKBgWq3I716oljvMOYiYwkRLVWYkipHbfgoRTjQE203JaeNqHWAwV9Gni,iv:Z6e77Kpozi5s62JMWIh2laX+6t6gQe98sWnfU+dnV54=,tag:XqG4dF7g0Eh15d6L3EIgtA==,type:str]
+sops:
+    age:
+        - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4dkl2VHBaeWJUaVdkR0s5
+            eEQvS2lGYW5nTlRDTTk0RVJzMjJDSnBla3lzCjJyTWs2a001UDA5ZzVQRlh1cm9C
+            dEJYc2ZjeDlhM0htQW42ejVxQTJXSm8KLS0tIE14dzBVUDBoNkoxN2ZlYzRWcjQ5
+            alNUbWNtZ2xXZSs3SW1TaTNMTmhvRHMKXhpABGdsV6KIzUYScpVsKvxqAk87FCWm
+            fuHV2Ph8xav59SI5unQxcCXiqMk0ZuSDmff31serO0kxb9DKJwDhtg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-20T06:12:33Z"
+    mac: ENC[AES256_GCM,data:QtiFnZJfoB6vMSsr1IG9keSs57IVVIdsiQs8DjrO/N5rxbGBdBXlZwg5zF/pLdMkTJOMfZbx7WdC++dIaV4SDaR4qOlJq3MX7z2wVWHo5+lT0dn0dJWMM22IaKyYo8aQeMEIBcdum1re4hQajmIZKWq74jdYFXmHRnB50VfgSv4=,iv:D2oR7+G5UyBWwAStE0oo6Me/CMHTsUAqlaPbCMItWsY=,tag:xxE92Wfyv1FBK4MKnC5SOQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/kubernetes/infrastructure/configs/pangolin-ns.yaml
+++ b/kubernetes/infrastructure/configs/pangolin-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pangolin


### PR DESCRIPTION
## Summary
- Add `pangolin` namespace and SOPS-encrypted Newt credentials secret
- Add ArgoCD Application for `fossorial/newt` Helm chart (v1.1.0)
- Newt connects to Pangolin and exposes K8s services (Prometheus, Loki) as private resources reachable by Machine Clients on VPS and other hosts

## Architecture
```
K8s Cluster → Newt pod (pangolin ns) → Pangolin (VPS)
VPS Machine Client → WireGuard → K8s private resources
```

## Test plan
- [ ] Flux deploys pangolin namespace + encrypted secret
- [ ] ArgoCD syncs Newt Application
- [ ] Newt pod connects to Pangolin (shows "Connected" in UI)
- [ ] Private resources (Prometheus, Loki) added in Pangolin UI
- [ ] VPS Machine Client can reach K8s services

🤖 Generated with [Claude Code](https://claude.com/claude-code)