### PR TITLE
fix(newt): add enabled flag to newtInstance

### DIFF
--- a/kubernetes/apps/argocd-apps/apps/newt.yaml
+++ b/kubernetes/apps/argocd-apps/apps/newt.yaml
@@ -18,6 +18,7 @@ spec:
             tag: "1.9.0"
         newtInstances:
           - name: homelab-k8s
+            enabled: true
             auth:
               existingSecretName: newt-credentials
               keys:


### PR DESCRIPTION
## Summary
- The fossorial/newt Helm chart template guards Deployment rendering with `{{- if $inst.enabled }}`, which defaults to false when not explicitly set
- Without `enabled: true`, the chart renders zero resources (only test hooks), so ArgoCD shows Synced/Healthy but no pod is created
- Adds `enabled: true` to the `homelab-k8s` newtInstance

## Test plan
- [ ] Verify ArgoCD syncs the Newt Application with a Deployment resource
- [ ] Verify Newt pod starts in `pangolin` namespace
- [ ] Verify Newt connects to Pangolin (check "Connected" status in Pangolin UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)