### PR TITLE
feat: VPS Machine Client and Alloy tunnel endpoints

### DIFF
--- a/docker/komodo-resources/procedures.toml
+++ b/docker/komodo-resources/procedures.toml
@@ -50,7 +50,7 @@ executions = [
 [[procedure.config.stage]]
 name = "Applications"
 executions = [
-  { execution.type = "BatchDeployStackIfChanged", execution.params.pattern = "*", execution.params.exclude_pattern = "komodo-core|aegis-pangolin|aegis-newt|aegis-periphery" },
+  { execution.type = "BatchDeployStackIfChanged", execution.params.pattern = "*", execution.params.exclude_pattern = "komodo-core|aegis-pangolin|aegis-newt|aegis-periphery|aegis-pangolin-client" },
 ]
 
 [[procedure]]
@@ -80,6 +80,12 @@ executions = [
 name = "Management Agent"
 executions = [
   { execution.type = "DeployStack", execution.params.stack = "aegis-periphery" },
+]
+
+[[procedure.config.stage]]
+name = "Observability Tunnel"
+executions = [
+  { execution.type = "DeployStack", execution.params.stack = "aegis-pangolin-client" },
 ]
 
 [[procedure.config.stage]]

--- a/docker/komodo-resources/stacks-racknerd-aegis.toml
+++ b/docker/komodo-resources/stacks-racknerd-aegis.toml
@@ -61,6 +61,19 @@ path = "docker/stacks/racknerd-aegis/newt"
 command = "sops-decrypt.sh"
 
 [[stack]]
+name = "aegis-pangolin-client"
+description = "Pangolin Machine Client — WireGuard routes to K8s private resources (Prometheus, Loki)"
+tags = ["networking", "racknerd-aegis"]
+[stack.config]
+server_id = "racknerd-aegis"
+file_paths = ["docker/stacks/racknerd-aegis/pangolin-client/compose.yaml"]
+repo = "mohitsharma44/homeops"
+branch = "main"
+[stack.config.pre_deploy]
+path = "docker/stacks/racknerd-aegis/pangolin-client"
+command = "sops-decrypt.sh"
+
+[[stack]]
 name = "racknerd-aegis-alloy"
 description = "Grafana Alloy monitoring agent for racknerd-aegis VPS"
 tags = ["monitoring", "racknerd-aegis"]
@@ -71,6 +84,8 @@ repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
 HOSTNAME=racknerd-aegis
+PROMETHEUS_URL=http://k8s-prometheus.private.sharmamohit.com:9090/api/v1/write
+LOKI_URL=http://k8s-loki.private.sharmamohit.com:3100/loki/api/v1/push
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/stacks/racknerd-aegis/pangolin-client/.sops.env
+++ b/docker/stacks/racknerd-aegis/pangolin-client/.sops.env
@@ -1,0 +1,9 @@
+PANGOLIN_ENDPOINT=ENC[AES256_GCM,data:11QWVDAt5JTL8j/BFHb8Zv6gc4I9aHjo2UC1js7nIPJbKalA7AU=,iv:ZYvnNKjvdfN32GtpYul9k1g7CBHVubxDlepe0lyQ2ew=,tag:VliN7aZlT4uW2qoFndh4vA==,type:str]
+CLIENT_ID=ENC[AES256_GCM,data:Rqv19sJWPSnEF/Qy5uFr,iv:HEB6/M85VcUudNc4sz180u1ICPqZmiZYRixLf16MWk8=,tag:IlRz942LIRLimNivKanohQ==,type:str]
+CLIENT_SECRET=ENC[AES256_GCM,data:fUoDekBtKJ3zYbLuWk70msiMhWm1OosPAJRDtoGus+mO6lCmG+HxV/RWHqERxl+S,iv:K0ufzFlEEIyDQeSNgxllO1zkJl6vbXeGYPRDPawPCNg=,tag:bz92xvi+2YmuOKNOPKDHhw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrK1BjWDM5RE5qeFVxS1Nk\nTys2NTZ6TDR6Lys4UmdtbklWRkJ5MzJEb2xRCmdIWlArQ1A1QisxcGZaTmxma0w3\nYnRKS0E4TlZxeGhYUGV2Umg5a2U2LzgKLS0tIFlBZWg4cGVUR3F6N2UwNzZhbGcv\nL1U1OFczd2RtTzJWa2dLSnNDbzNKWmcKolwn9WnnTVPYNfbbKT0k4rl7lwvf5jJu\nJQJWAPUs+Ap061Y3VYTsyRUFuXC0CT+duMBErcEhYO7J8w1QxL56Uw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+sops_lastmodified=2026-02-21T05:11:53Z
+sops_mac=ENC[AES256_GCM,data:gTbWc4WjRZv00k4Uq5GczNtE+FMr/tSKDWehyVe3kXPpfIA0OPnePgSpxvawKfGPvTfrJT2AedS07Njj1XqsSmQ/49HqptU8Rv3Ce89oQtWDTv5KwLhhIRvK99XlgjhWsS0ivVrHqPguUbv6toRN/YDopM+vNBQXbau8Gqnb/Ec=,iv:5C7rUSB4d5KEMAlgeG/av9b/Vpubwkz4J7Mbvxaw9vY=,tag:aWX0fvQ5bo0HCizppg5+pQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.11.0

--- a/docker/stacks/racknerd-aegis/pangolin-client/compose.yaml
+++ b/docker/stacks/racknerd-aegis/pangolin-client/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  pangolin-cli:
+    image: fosrl/pangolin-cli:0.3.3
+    container_name: pangolin-client-obs
+    restart: unless-stopped
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    env_file:
+      - .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
- Adds `aegis-pangolin-client` stack — `fosrl/pangolin-cli:0.3.3` Machine Client on VPS that creates WireGuard routes to K8s private resources (Prometheus, Loki) via Pangolin tunnel
- Overrides VPS Alloy's `PROMETHEUS_URL` and `LOKI_URL` to use Pangolin tunnel DNS (`k8s-prometheus.private.sharmamohit.com:9090`, `k8s-loki.private.sharmamohit.com:3100`) instead of public ingress
- Excludes `aegis-pangolin-client` from batch deploy (tunnel-critical, same as pangolin/newt/periphery)
- Adds "Observability Tunnel" stage to `deploy-vps-infra` procedure between periphery and identity/monitoring

## Test plan
- [x] Machine Client deployed manually on VPS — connected via Gerbil relay
- [x] DNS resolution confirmed: `k8s-prometheus.private.sharmamohit.com` → `100.96.128.9`
- [x] `curl http://k8s-prometheus.private.sharmamohit.com:9090/-/healthy` → "Prometheus Server is Healthy."
- [x] `curl http://k8s-loki.private.sharmamohit.com:3100/ready` → "ready"
- [ ] After merge: sync to Komodo, redeploy Alloy with tunnel URLs, verify metrics flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)