### PR TITLE
refactor(alloy): separate config from secrets for per-host overrides

### DIFF
--- a/docker/stacks/shared/alloy/.sops.env
+++ b/docker/stacks/shared/alloy/.sops.env
@@ -1,10 +1,8 @@
-PROMETHEUS_URL=ENC[AES256_GCM,data:HCFBmrcFyhKjuAskPGyFJJY7mGQHQlvyafr9YPYk7w193eRi+a3pfRgDlYcEXEs=,iv:RZTpkrOarTpCAuxfml8Q01kPNKWrgy6IO9A2Wl5WQKw=,tag:rNe76uAgHb1J2+A7PFqvmA==,type:str]
-LOKI_URL=ENC[AES256_GCM,data:Hicc+NowZCicwq8T4G/+H6OoYcmOeTHioQ7SYh34zWkBodKo5FdFVEdTDlin,iv:SzTIBIRjTiVhxUq4Bi+R+OQsBhFuYpI2NdUdvMdRVyA=,tag:v3SfabxjQSPvTYvjt0vG6A==,type:str]
-BASIC_AUTH_USERNAME=ENC[AES256_GCM,data:uVb2ilo=,iv:w8kmaJxbA17qqOLTvf3kZCKONA4/sDQC87zziut3P7Y=,tag:EFYuod47+3CWfE/aZM7TtQ==,type:str]
-BASIC_AUTH_PASSWORD=ENC[AES256_GCM,data:6LpzhbzOE2xIGL6nWUlbF6PV26fbmAog0ae7vX9umfZjrEmmN2xfQVX7vQ==,iv:KTDMZN8gF6azb89LThUxBmf1Yat0fk9SLYFJ/e+1CGM=,tag:7j+8xeEZ70WudBkjhgr1Hw==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGODl5Q3RXVDlhTmxaTjEy\nZDhlRXhnVCtHekVUbk1QTnFrTi9iNHRIblg0Ci9wL3BkTWdqQTdsQk9RVFl4c3Z1\nK3JTcHQrNFJwRVVtUHdVUGhNSyt2M28KLS0tIHFwQ1N3WjJqVTFOQW4xRzN2R2dx\ncm1rVVdiZFpXOUNpcEM1dWpDUmNGN2sKeGiiBi/FiRHScJLgWldqJmNBBDDYom1H\n5Mq+Hcf45elkvRQT7AvcH+N1Q1mWtpRUnWrH2cajnh5fty4Mmvbp5A==\n-----END AGE ENCRYPTED FILE-----\n
+BASIC_AUTH_USERNAME=ENC[AES256_GCM,data:FSVhLrM=,iv:el3EbNPjqGwS3KFKTLLqAvGyelyYjhC5HYB0EhgcLZQ=,tag:gwtkPV1gKH2EWi2sTzL/8w==,type:str]
+BASIC_AUTH_PASSWORD=ENC[AES256_GCM,data:2nZfy5ZthxqbQSYI9RON6CIVD1BWH5zQYzWYL0+j55oKHEsAFKmK4ssruQ==,iv:s3lOrszgTSISb+LoM53P4iseeVTLeZ+DiYcaeOH4T/4=,tag:IdMwTxW8NCKljPcOSZHJ6g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3ajdMbVF5Mk1nRTVsTjFJ\nWkMzcm1HeWdjK1RlQ0RMRk9WR0ZRYVFKK3k4CmFiMlQzTDZFbFpPNnd4UkIvL3Jt\ncDBUZDdlNVFVN2FWRmZRb29NQVFaSlEKLS0tIG0xSjU3c2haNC8vZmNMQUJOdGJi\nSDVaUzMvdVIwTmp4OEIzejhad0lEWEkKrNvoGairGRLTN0oDJwDKcBbleMpvmBeP\nNvGLclmy4hmwPTJtBDn1QrxueMmnYWzxG+gMcyjkdw/LpB2ymBSEVg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
-sops_lastmodified=2026-02-14T22:02:50Z
-sops_mac=ENC[AES256_GCM,data:gXllQdTm12TJeSepz7TzgVJtjZCMlMsPofXprNpcsjc93Dn7PTMfzPpRsKQgDvLL8mBOPbVhL++bp85gcm7LZ8WpVFGVKz/HhZ4lqfn25YwArXywyMz2Wrb+x+CaL/3OrXnoQBalwjX/6vqvfGtqFPDc2qOuUlna7dDNWSJhVT4=,iv:4pyqvI6I7dtibN+SggQffwb1n0RuN4GCD64cCgOIR1g=,tag:h/XY82/UWk9HMfxEgXEg+g==,type:str]
+sops_lastmodified=2026-02-21T06:01:45Z
+sops_mac=ENC[AES256_GCM,data:SUdf63gkUXJDzBA3scr/YJfUdziT3NJYIAW8RWZCf9lza/JMXq1xsKMsA+BW9bmwR97o8iOQFoGyNno9DcntQMkbY/OJnP482EcEGLlXOnUyK3J3BgMuC/qxLa9luSs3Lg+To+dF6L/Eh/rn54/RNHN6/Xyw7nokQoLKeUyjMGw=,iv:JatA+eAZbWAhZr0HoGih9bytqZ/W9nAD8oZiaj4f918=,tag:hrIcP7hKS9vLgvwjjhdu8Q==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/docker/stacks/shared/alloy/compose.yaml
+++ b/docker/stacks/shared/alloy/compose.yaml
@@ -30,6 +30,10 @@ services:
       - --stability.level=generally-available
     env_file:
       - .env
+    environment:
+      HOSTNAME: ${HOSTNAME:-}
+      PROMETHEUS_URL: ${PROMETHEUS_URL:-https://prometheus.sharmamohit.com/api/v1/write}
+      LOKI_URL: ${LOKI_URL:-https://loki.sharmamohit.com/loki/api/v1/push}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:12345/-/ready"]


### PR DESCRIPTION
## Summary
- Move non-secret config (`PROMETHEUS_URL`, `LOKI_URL`) from `.sops.env` to compose `environment:` with `${VAR:-default}` interpolation
- `.sops.env` now contains only actual secrets (`BASIC_AUTH_*`)
- Komodo's per-stack `environment` field (project `.env`) now correctly drives per-host overrides via Docker Compose variable substitution
- Fixes `HOSTNAME` never reaching the container (was broken for all 7 hosts)

**How it works:**
- `env_file: .env` provides secrets (BASIC_AUTH) to the container
- `environment:` provides config with sensible defaults; `${VAR:-default}` is interpolated from the project `.env` (written by Komodo's `environment` field)
- `environment:` takes precedence over `env_file:` for the same key
- Non-VPS hosts: no URL override → defaults (public ingress)
- VPS: `PROMETHEUS_URL`/`LOKI_URL` in Komodo env → tunnel endpoints override defaults

## Test plan
- [ ] After merge: sync + redeploy VPS Alloy → verify tunnel URLs in container env
- [ ] Redeploy one non-VPS Alloy (e.g., komodo-alloy) → verify default URLs still work
- [ ] Verify `HOSTNAME` label appears correctly in Grafana for all hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)