### PR TITLE
fix(alloy): rename HOSTNAME to INSTANCE_NAME to avoid Docker override

### DIFF
--- a/docker/stacks/shared/alloy/compose.yaml
+++ b/docker/stacks/shared/alloy/compose.yaml
@@ -1,6 +1,6 @@
 # Shared Alloy monitoring stack — deployed on every Docker host.
-# Per-host non-secret overrides (like HOSTNAME) are set via Komodo's
-# `environment` field in each host's stack TOML definition.
+# Per-host non-secret overrides (like HOSTNAME → INSTANCE_NAME) are set via
+# Komodo's `environment` field in each host's stack TOML definition.
 services:
   alloy:
     image: grafana/alloy:v1.13.1
@@ -31,7 +31,8 @@ services:
     env_file:
       - .env
     environment:
-      HOSTNAME: ${HOSTNAME:-}
+      # Docker reserves HOSTNAME, so map it to INSTANCE_NAME for Alloy
+      INSTANCE_NAME: ${HOSTNAME:-}
       PROMETHEUS_URL: ${PROMETHEUS_URL:-https://prometheus.sharmamohit.com/api/v1/write}
       LOKI_URL: ${LOKI_URL:-https://loki.sharmamohit.com/loki/api/v1/push}
     restart: unless-stopped
@@ -88,7 +89,7 @@ configs:
         }
 
         // ============================================================
-        // Relabel: add instance label from HOSTNAME env var
+        // Relabel: add instance label from INSTANCE_NAME env var
         // ============================================================
 
         prometheus.relabel "instance" {
@@ -97,7 +98,7 @@ configs:
           rule {
             action       = "replace"
             target_label = "instance"
-            replacement  = sys.env("HOSTNAME")
+            replacement  = sys.env("INSTANCE_NAME")
           }
         }
 
@@ -142,7 +143,7 @@ configs:
           rule {
             action       = "replace"
             target_label = "instance"
-            replacement  = sys.env("HOSTNAME")
+            replacement  = sys.env("INSTANCE_NAME")
           }
         }
 


### PR DESCRIPTION
## Summary
- Docker reserves `HOSTNAME` env var and always overrides it with the container ID at runtime
- Renamed container env var to `INSTANCE_NAME` while keeping `${HOSTNAME:-}` for compose interpolation (what Komodo provides)
- Updated both `prometheus.relabel` and `discovery.relabel` references in the Alloy config to use `sys.env("INSTANCE_NAME")`

This fixes the `instance` label in all metrics and logs — previously showed container IDs instead of host names.

## Test plan
- [ ] Deploy VPS Alloy, verify `INSTANCE_NAME=racknerd-aegis` in container env
- [ ] Deploy one non-VPS Alloy (e.g., komodo-alloy), verify `INSTANCE_NAME=komodo`
- [ ] Check Grafana for correct `instance` labels on metrics and logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)