### PR TITLE
fix(alloy): use INSTANCE_NAME for compose interpolation and container env

### DIFF
--- a/docker/komodo-resources/stacks-kasm.toml
+++ b/docker/komodo-resources/stacks-kasm.toml
@@ -24,7 +24,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=kasm
+INSTANCE_NAME=kasm
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/komodo-resources/stacks-komodo.toml
+++ b/docker/komodo-resources/stacks-komodo.toml
@@ -21,7 +21,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=komodo
+INSTANCE_NAME=komodo
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/komodo-resources/stacks-nvr.toml
+++ b/docker/komodo-resources/stacks-nvr.toml
@@ -18,7 +18,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=nvr
+INSTANCE_NAME=nvr
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/komodo-resources/stacks-omni.toml
+++ b/docker/komodo-resources/stacks-omni.toml
@@ -21,7 +21,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=omni
+INSTANCE_NAME=omni
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/komodo-resources/stacks-racknerd-aegis.toml
+++ b/docker/komodo-resources/stacks-racknerd-aegis.toml
@@ -83,7 +83,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=racknerd-aegis
+INSTANCE_NAME=racknerd-aegis
 PROMETHEUS_URL=http://k8s-prometheus.private.sharmamohit.com:9090/api/v1/write
 LOKI_URL=http://k8s-loki.private.sharmamohit.com:3100/loki/api/v1/push
 """

--- a/docker/komodo-resources/stacks-seaweedfs.toml
+++ b/docker/komodo-resources/stacks-seaweedfs.toml
@@ -21,7 +21,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=seaweedfs
+INSTANCE_NAME=seaweedfs
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/komodo-resources/stacks-server04.toml
+++ b/docker/komodo-resources/stacks-server04.toml
@@ -37,7 +37,7 @@ file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """
-HOSTNAME=server04
+INSTANCE_NAME=server04
 """
 [stack.config.pre_deploy]
 path = "docker/stacks/shared/alloy"

--- a/docker/stacks/shared/alloy/compose.yaml
+++ b/docker/stacks/shared/alloy/compose.yaml
@@ -1,6 +1,6 @@
 # Shared Alloy monitoring stack — deployed on every Docker host.
-# Per-host non-secret overrides (like HOSTNAME → INSTANCE_NAME) are set via
-# Komodo's `environment` field in each host's stack TOML definition.
+# Per-host non-secret overrides (like INSTANCE_NAME) are set via Komodo's
+# `environment` field in each host's stack TOML definition.
 services:
   alloy:
     image: grafana/alloy:v1.13.1
@@ -31,8 +31,8 @@ services:
     env_file:
       - .env
     environment:
-      # Docker reserves HOSTNAME, so map it to INSTANCE_NAME for Alloy
-      INSTANCE_NAME: ${HOSTNAME:-}
+      # Docker reserves HOSTNAME (shell + container runtime), so use INSTANCE_NAME everywhere
+      INSTANCE_NAME: ${INSTANCE_NAME:-}
       PROMETHEUS_URL: ${PROMETHEUS_URL:-https://prometheus.sharmamohit.com/api/v1/write}
       LOKI_URL: ${LOKI_URL:-https://loki.sharmamohit.com/loki/api/v1/push}
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- The Periphery container (which runs `docker compose`) has Docker's auto-set `HOSTNAME` in its shell env
- Shell env vars take precedence over `.env` file in compose `${VAR}` interpolation
- So `${HOSTNAME:-}` resolved to the Periphery's container ID, not the value from Komodo's environment field
- **Fix:** Rename to `INSTANCE_NAME` in both compose interpolation (`${INSTANCE_NAME:-}`) and all 7 Komodo TOML environment fields

## Files changed
- `docker/stacks/shared/alloy/compose.yaml` — `${HOSTNAME:-}` → `${INSTANCE_NAME:-}`
- All 7 `docker/komodo-resources/stacks-*.toml` — `HOSTNAME=<host>` → `INSTANCE_NAME=<host>`

## Test plan
- [ ] Deploy VPS Alloy, verify `INSTANCE_NAME=racknerd-aegis` in container env
- [ ] Deploy one non-VPS Alloy, verify correct instance name
- [ ] Check Grafana for correct `instance` labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)