### PR TITLE
fix(komodo): set explicit project name for komodo-core

### DIFF
--- a/docker/stacks/komodo/core/compose.yaml
+++ b/docker/stacks/komodo/core/compose.yaml
@@ -1,3 +1,5 @@
+name: komodo-core
+
 services:
   postgres:
     image: ghcr.io/ferretdb/postgres-documentdb:17-0.107.0-ferretdb-2.7.0


### PR DESCRIPTION
## Summary
- Adds top-level `name: komodo-core` to the Core compose file to prevent Docker Compose project name mismatch
- Without this, manual deploys default to directory name `core` instead of `komodo-core`, causing Komodo to report the stack as "down" despite all containers running healthy

## What happened
Komodo looks for Docker Compose project `komodo-core` (matching the stack name), but the compose was deployed with project name `core` (defaulting to the directory name). All containers were running fine — purely a naming mismatch.

## Fix applied (live)
Restarted the project under the correct name on komodo host:
```bash
docker compose -p core down && docker compose -p komodo-core up -d
```
External volumes (`komodo_postgres-data`, `komodo_ferretdb-state`) preserved all data. No data loss.

## Test plan
- [x] Verified `km list stacks -a` shows `komodo-core` as `running`
- [x] Verified all 3 containers healthy (`docker ps` on komodo)
- [ ] After merge + sync, verify `km execute deploy-stack komodo-core` uses correct project name

🤖 Generated with [Claude Code](https://claude.com/claude-code)