### PR TITLE
feat(monitoring): add CrowdSec Prometheus metrics scraping on VPS

### DIFF
--- a/docker/komodo-resources/stacks-racknerd-aegis.toml
+++ b/docker/komodo-resources/stacks-racknerd-aegis.toml
@@ -79,7 +79,7 @@ description = "Grafana Alloy monitoring agent for racknerd-aegis VPS"
 tags = ["monitoring", "racknerd-aegis"]
 [stack.config]
 server_id = "racknerd-aegis"
-file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
+file_paths = ["docker/stacks/shared/alloy/compose.yaml", "docker/stacks/racknerd-aegis/alloy-override/compose.yaml"]
 repo = "mohitsharma44/homeops"
 branch = "main"
 environment = """

--- a/docker/stacks/racknerd-aegis/aegis-gateway/compose.yaml
+++ b/docker/stacks/racknerd-aegis/aegis-gateway/compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     networks:
       - traefik-public
+    ports:
+      - "127.0.0.1:6060:6060" # Prometheus metrics — loopback only, NOT exposed to WAN
     environment:
       TZ: America/New_York
       COLLECTIONS: "crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/base-http-scenarios"

--- a/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
+++ b/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
@@ -1,0 +1,131 @@
+# VPS-specific Alloy config override — adds CrowdSec metrics scraping.
+# Merged with docker/stacks/shared/alloy/compose.yaml via Komodo file_paths.
+# Docker Compose merge replaces configs with the same name, so this
+# must contain the full shared config PLUS the CrowdSec scrape block.
+configs:
+  alloy-config:
+    content: |
+        // ============================================================
+        // Host metrics (node_exporter)
+        // ============================================================
+
+        prometheus.exporter.unix "host" {
+          procfs_path = "/host/proc"
+          sysfs_path  = "/host/sys"
+          rootfs_path = "/host/rootfs"
+        }
+
+        prometheus.scrape "host" {
+          targets         = prometheus.exporter.unix.host.targets
+          forward_to      = [prometheus.relabel.instance.receiver]
+          scrape_interval = "60s"
+          job_name        = "node"
+        }
+
+        // ============================================================
+        // Container metrics (cAdvisor)
+        // ============================================================
+
+        prometheus.exporter.cadvisor "containers" {
+          docker_host = "unix:///var/run/docker.sock"
+        }
+
+        prometheus.scrape "containers" {
+          targets         = prometheus.exporter.cadvisor.containers.targets
+          forward_to      = [prometheus.relabel.instance.receiver]
+          scrape_interval = "60s"
+          job_name        = "cadvisor"
+        }
+
+        // ============================================================
+        // CrowdSec metrics (VPS only)
+        // ============================================================
+
+        prometheus.scrape "crowdsec" {
+          targets         = [{"__address__" = "localhost:6060"}]
+          forward_to      = [prometheus.relabel.instance.receiver]
+          scrape_interval = "60s"
+          metrics_path    = "/metrics"
+          job_name        = "crowdsec"
+        }
+
+        // ============================================================
+        // Relabel: add instance label from INSTANCE_NAME env var
+        // ============================================================
+
+        prometheus.relabel "instance" {
+          forward_to = [prometheus.remote_write.prometheus.receiver]
+
+          rule {
+            action       = "replace"
+            target_label = "instance"
+            replacement  = sys.env("INSTANCE_NAME")
+          }
+        }
+
+        // ============================================================
+        // Remote write: push metrics to K8s Prometheus
+        // ============================================================
+
+        prometheus.remote_write "prometheus" {
+          external_labels = {
+            source = "docker",
+          }
+
+          endpoint {
+            url = sys.env("PROMETHEUS_URL")
+
+            basic_auth {
+              username = sys.env("BASIC_AUTH_USERNAME")
+              password = sys.env("BASIC_AUTH_PASSWORD")
+            }
+          }
+        }
+
+        // ============================================================
+        // Container logs via Docker
+        // ============================================================
+
+        discovery.docker "containers" {
+          host = "unix:///var/run/docker.sock"
+        }
+
+        discovery.relabel "docker_logs" {
+          targets = discovery.docker.containers.targets
+
+          rule {
+            source_labels = ["__meta_docker_container_name"]
+            target_label  = "container"
+          }
+          rule {
+            source_labels = ["__meta_docker_image_name"]
+            target_label  = "image"
+          }
+          rule {
+            action       = "replace"
+            target_label = "instance"
+            replacement  = sys.env("INSTANCE_NAME")
+          }
+        }
+
+        loki.source.docker "containers" {
+          host       = "unix:///var/run/docker.sock"
+          targets    = discovery.relabel.docker_logs.output
+          forward_to = [loki.write.loki.receiver]
+        }
+
+        // ============================================================
+        // Loki write: push logs to K8s Loki
+        // ============================================================
+
+        loki.write "loki" {
+          endpoint {
+            url       = sys.env("LOKI_URL")
+            tenant_id = "homelab"
+
+            basic_auth {
+              username = sys.env("BASIC_AUTH_USERNAME")
+              password = sys.env("BASIC_AUTH_PASSWORD")
+            }
+          }
+        }


### PR DESCRIPTION
## Summary

- Publish CrowdSec metrics port 6060 to host loopback (`127.0.0.1:6060:6060`) so Alloy can scrape it without exposing to WAN
- Add VPS-specific Alloy config override (`alloy-override/compose.yaml`) with a `prometheus.scrape "crowdsec"` block targeting `localhost:6060`
- Update Komodo stack definition to merge the override via `file_paths` — no changes to the shared Alloy config used by all 7 hosts

## Test plan

- [ ] After merge, sync and deploy: `km execute -y sync 'mohitsharma44/homeops'`
- [ ] Redeploy aegis-gateway: `km execute -y deploy-stack aegis-gateway`
- [ ] Redeploy VPS Alloy: `km execute -y deploy-stack racknerd-aegis-alloy`
- [ ] Verify CrowdSec metrics on loopback: `ssh hs "curl -s localhost:6060/metrics | head -5"`
- [ ] Verify metrics in Prometheus: query `cs_active_decisions{instance="racknerd-aegis"}`
- [ ] Verify other hosts unaffected: no config changes on other Alloy stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)