### PR TITLE
feat(monitoring): add SMART disk and ZFS pool health alert rules

### DIFF
--- a/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -239,6 +239,93 @@ spec:
                       severity: warning
                     annotations:
                       summary: "CPU usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}"
+          infra-smart-health:
+            groups:
+              - name: infra-smart-health
+                rules:
+                  - alert: SmartDiskUnhealthy
+                    expr: smartctl_device_smart_status{source="docker"} != 1
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "SMART health check FAILED on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartReallocatedSectorsGrowing
+                    expr: |
+                      increase(smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw",source="docker"}[24h]) > 0
+                    for: 5m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: "Reallocated sectors increasing on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartPendingSectorsGrowing
+                    expr: |
+                      increase(smartctl_device_attribute{attribute_name="Current_Pending_Sector",attribute_value_type="raw",source="docker"}[24h]) > 0
+                    for: 5m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: "Pending sectors increasing on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartDiskTemperatureHigh
+                    expr: smartctl_device_temperature{temperature_type="current",source="docker"} > 55
+                    for: 10m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: "Disk temperature {{ $value }}C on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartDiskTemperatureCritical
+                    expr: smartctl_device_temperature{temperature_type="current",source="docker"} > 65
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "Disk temperature critical {{ $value }}C on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartNvmeMediaErrors
+                    expr: increase(smartctl_device_media_errors{source="docker"}[24h]) > 0
+                    for: 5m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: "NVMe media errors increasing on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartNvmeCriticalWarning
+                    expr: smartctl_device_critical_warning{source="docker"} > 0
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "NVMe critical warning on {{ $labels.device }} ({{ $labels.instance }})"
+                  - alert: SmartExporterDown
+                    expr: up{job="smartctl", source="docker"} == 0
+                    for: 5m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: "smartctl_exporter down on {{ $labels.instance }}"
+          infra-zfs-health:
+            groups:
+              - name: infra-zfs-health
+                rules:
+                  - alert: ZfsPoolDegraded
+                    expr: node_zfs_zpool_state{state="degraded", source="docker"} == 1
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "ZFS pool {{ $labels.zpool }} is DEGRADED on {{ $labels.instance }}"
+                  - alert: ZfsPoolFaulted
+                    expr: node_zfs_zpool_state{state="faulted", source="docker"} == 1
+                    for: 1m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "ZFS pool {{ $labels.zpool }} is FAULTED on {{ $labels.instance }}"
+                  - alert: ZfsPoolUnavail
+                    expr: node_zfs_zpool_state{state="unavail", source="docker"} == 1
+                    for: 1m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: "ZFS pool {{ $labels.zpool }} is UNAVAILABLE on {{ $labels.instance }}"
           infra-watchdog:
             groups:
               - name: infra-watchdog


### PR DESCRIPTION
## Summary
- Add 8 SMART disk health PrometheusRules (Phase 4): disk unhealthy, reallocated/pending sectors growing, temperature thresholds, NVMe errors, exporter availability
- Add 3 ZFS pool health PrometheusRules (Phase 5): degraded, faulted, unavailable pool states
- Temperature alerts filter on `temperature_type="current"` to avoid false positives from `drive_trip` manufacturer shutdown thresholds (server04 SAS drives report 60°C drive_trip values)
- Update hardware monitoring plan: document truenas manual binary install, mark all phases complete

## Alert rules added

### SMART Disk Health
| Alert | Severity | Trigger |
|-------|----------|---------|
| SmartDiskUnhealthy | critical | SMART health != 1 |
| SmartReallocatedSectorsGrowing | warning | increase over 24h |
| SmartPendingSectorsGrowing | warning | increase over 24h |
| SmartDiskTemperatureHigh | warning | >55°C current temp |
| SmartDiskTemperatureCritical | critical | >65°C current temp |
| SmartNvmeMediaErrors | warning | increase over 24h |
| SmartNvmeCriticalWarning | critical | NVMe critical flag |
| SmartExporterDown | warning | exporter unreachable |

### ZFS Pool Health
| Alert | Severity | Trigger |
|-------|----------|---------|
| ZfsPoolDegraded | critical | pool lost redundancy |
| ZfsPoolFaulted | critical | pool unrecoverable |
| ZfsPoolUnavail | critical | pool inaccessible |

## Validation
- All alert expressions tested against live Prometheus data
- No false positives on current fleet (21 drives across 3 hosts, 4 ZFS pools)
- NVMe rules are future-proofing (no NVMe drives currently)

## Test plan
- [ ] Verify ArgoCD syncs the new PrometheusRules
- [ ] Check Prometheus `/rules` endpoint shows new rule groups
- [ ] Confirm no alerts firing (all drives healthy, all pools online)
- [ ] Optionally verify alert routing by triggering a test alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)