### PR TITLE
feat(monitoring): deploy smartctl-exporter DaemonSet for Talos nodes

### DIFF
--- a/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -244,7 +244,7 @@ spec:
               - name: infra-smart-health
                 rules:
                   - alert: SmartDiskUnhealthy
-                    expr: smartctl_device_smart_status{source="docker"} != 1
+                    expr: smartctl_device_smart_status != 1
                     for: 5m
                     labels:
                       severity: critical
@@ -252,7 +252,7 @@ spec:
                       summary: "SMART health check FAILED on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartReallocatedSectorsGrowing
                     expr: |
-                      increase(smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw",source="docker"}[24h]) > 0
+                      increase(smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw"}[24h]) > 0
                     for: 5m
                     labels:
                       severity: warning
@@ -260,42 +260,42 @@ spec:
                       summary: "Reallocated sectors increasing on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartPendingSectorsGrowing
                     expr: |
-                      increase(smartctl_device_attribute{attribute_name="Current_Pending_Sector",attribute_value_type="raw",source="docker"}[24h]) > 0
+                      increase(smartctl_device_attribute{attribute_name="Current_Pending_Sector",attribute_value_type="raw"}[24h]) > 0
                     for: 5m
                     labels:
                       severity: warning
                     annotations:
                       summary: "Pending sectors increasing on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartDiskTemperatureHigh
-                    expr: smartctl_device_temperature{temperature_type="current",source="docker"} > 55
+                    expr: smartctl_device_temperature{temperature_type="current"} > 55
                     for: 10m
                     labels:
                       severity: warning
                     annotations:
                       summary: "Disk temperature {{ $value }}C on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartDiskTemperatureCritical
-                    expr: smartctl_device_temperature{temperature_type="current",source="docker"} > 65
+                    expr: smartctl_device_temperature{temperature_type="current"} > 65
                     for: 5m
                     labels:
                       severity: critical
                     annotations:
                       summary: "Disk temperature critical {{ $value }}C on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartNvmeMediaErrors
-                    expr: increase(smartctl_device_media_errors{source="docker"}[24h]) > 0
+                    expr: increase(smartctl_device_media_errors[24h]) > 0
                     for: 5m
                     labels:
                       severity: warning
                     annotations:
                       summary: "NVMe media errors increasing on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartNvmeCriticalWarning
-                    expr: smartctl_device_critical_warning{source="docker"} > 0
+                    expr: smartctl_device_critical_warning > 0
                     for: 5m
                     labels:
                       severity: critical
                     annotations:
                       summary: "NVMe critical warning on {{ $labels.device }} ({{ $labels.instance }})"
                   - alert: SmartExporterDown
-                    expr: up{job="smartctl", source="docker"} == 0
+                    expr: up{job="smartctl"} == 0
                     for: 5m
                     labels:
                       severity: warning

--- a/kubernetes/apps/argocd-apps/apps/smartctl-exporter.yaml
+++ b/kubernetes/apps/argocd-apps/apps/smartctl-exporter.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: smartctl-exporter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: monitoring
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: prometheus-smartctl-exporter
+    targetRevision: "0.x"
+    helm:
+      valuesObject:
+        serviceMonitor:
+          enabled: true
+          relabelings:
+            - targetLabel: job
+              replacement: smartctl
+        tolerations:
+          - operator: Exists
+            effect: NoSchedule
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Deploy `prometheus-smartctl-exporter` as a privileged DaemonSet on all K8s (Talos) nodes to monitor NVMe drive health
- Remove `source="docker"` filter from all SMART alert rules so they match metrics from both bare-metal hosts and K8s nodes
- ZFS rules retain `source="docker"` since ZFS only runs on TrueNAS

## Details

### smartctl-exporter DaemonSet
- Helm chart: `prometheus-community/prometheus-smartctl-exporter` (0.x)
- Namespace: `monitoring` (already has `privileged` PSA enforcement)
- ServiceMonitor enabled with `job="smartctl"` relabeling to match Docker host job labels
- Tolerates all `NoSchedule` taints (runs on control-plane nodes)
- Resources: 50m CPU / 64-128Mi memory

### Alert rule changes
All 8 SMART alert rules had `source="docker"` removed so they apply universally:
- `SmartDiskUnhealthy`, `SmartReallocatedSectorsGrowing`, `SmartPendingSectorsGrowing`
- `SmartDiskTemperatureHigh`, `SmartDiskTemperatureCritical`
- `SmartNvmeMediaErrors`, `SmartNvmeCriticalWarning`, `SmartExporterDown`

### Cluster inventory (6 NVMe drives)
| Node | Drive 1 | Drive 2 |
|------|---------|---------|
| 192.168.11.19 | Crucial CT500P3PSSD8 500GB | WD BLACK SN850X 1TB |
| 192.168.11.21 | Crucial CT500P3PSSD8 500GB | WD BLACK SN850X 1TB |
| 192.168.11.22 | Crucial CT500P3PSSD8 500GB | WD BLACK SN850X 1TB |

## Test plan
- [ ] ArgoCD syncs smartctl-exporter Application successfully
- [ ] DaemonSet pods run on all 3 Talos nodes
- [ ] `smartctl_device_smart_status` metric appears in Prometheus for all 6 NVMe drives
- [ ] ServiceMonitor target shows `job="smartctl"` label
- [ ] Existing Docker host SMART metrics still match alert rules (no regression)
- [ ] `SmartExporterDown` alert does not fire (all exporters healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)