### PR TITLE
refactor(monitoring): rename source=docker to source=infra + smartctl relabeling

### DIFF
--- a/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
+++ b/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
@@ -121,7 +121,7 @@ configs:
 
         prometheus.remote_write "prometheus" {
           external_labels = {
-            source = "docker",
+            source = "infra",
           }
 
           endpoint {

--- a/docker/stacks/shared/alloy/compose.yaml
+++ b/docker/stacks/shared/alloy/compose.yaml
@@ -108,7 +108,7 @@ configs:
 
         prometheus.remote_write "prometheus" {
           external_labels = {
-            source = "docker",
+            source = "infra",
           }
 
           endpoint {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,7 +404,7 @@ Emergency backdoor: SSH
 │                     │ Retention: raw=7d, 5m=30d, 1h=180d  │            │   │
 │                     └─────────────────────────────────────┘            │   │
 │                                                                        │   │
-│  All metrics carry: source="docker", instance="<INSTANCE_NAME>"       │   │
+│  All metrics carry: source="infra", instance="<INSTANCE_NAME>"       │   │
 │  job="node" (host metrics), job="cadvisor" (container metrics)         │   │
 └────────────────────────────────────────────────────────────────────────┘
 

--- a/docs/hardware-monitoring-plan.md
+++ b/docs/hardware-monitoring-plan.md
@@ -165,9 +165,9 @@ alertmanager:
 
 These work with existing node_exporter metrics (no new exporters needed).
 
-**Note on `source` label**: All non-K8s Alloy instances (both Docker-managed and bare-metal systemd) use `source = "docker"` as an external label. The name is historical — it means "not Kubernetes", not literally "runs Docker". This keeps alert expressions simple and avoids a disruptive rename of existing Docker Alloy instances. The bare-metal pve/truenas Alloy configs use the same label for consistency.
+**Note on `source` label**: All non-K8s Alloy instances (both Docker-managed and bare-metal systemd) use `source = "infra"` as an external label, identifying them as infrastructure hosts managed outside the K8s cluster. The bare-metal pve/truenas Alloy configs use the same label for consistency.
 
-- `InfraHostDown`: `up{job="integrations/unix", source="docker"} == 0` for 5m — critical
+- `InfraHostDown`: `up{job="integrations/unix", source="infra"} == 0` for 5m — critical
 - `FilesystemSpaceLow`: >85% full for 15m — warning
 - `FilesystemSpaceCritical`: >95% full for 5m — critical
 - `FilesystemWillFillIn24h`: linear prediction — warning
@@ -350,9 +350,9 @@ prometheus.relabel "instance" {
 // Remote write: push metrics to K8s Prometheus
 // ============================================================
 prometheus.remote_write "prometheus" {
-  // "docker" is a historical label meaning "non-K8s infrastructure".
+  // "infra" identifies non-K8s infrastructure hosts.
   external_labels = {
-    source = "docker",
+    source = "infra",
   }
   endpoint {
     url = sys.env("PROMETHEUS_URL")
@@ -508,10 +508,10 @@ prometheus.relabel "instance" {
 // Remote write: push metrics to K8s Prometheus
 // ============================================================
 prometheus.remote_write "prometheus" {
-  // "docker" is a historical label meaning "non-K8s infrastructure".
+  // "infra" identifies non-K8s infrastructure hosts.
   // Bare-metal hosts use the same label for consistent alert expressions.
   external_labels = {
-    source = "docker",
+    source = "infra",
   }
   endpoint {
     url = sys.env("PROMETHEUS_URL")
@@ -783,7 +783,7 @@ If credentials need to be rotated:
 |----|---------|------------|
 | A1 | Warnings never reach HA (routing bug) | Added explicit warning→HA route with `continue: true` |
 | A2 | Watchdog spams phone | Routed to `null` receiver; documented DMS replacement |
-| A3 | `source="docker"` label wrong for bare-metal | Kept for alert expression compatibility; documented as historical naming |
+| A3 | `source="docker"` label wrong for bare-metal | Renamed to `source="infra"` to accurately reflect infrastructure hosts |
 | A4 | No journal shipping from pve/truenas | Added `loki.source.journal` to River config; `alloy` user added to `systemd-journal` group |
 | A5 | smartctl_exporter shared template binds 0.0.0.0 | Changed to `127.0.0.1:9633` |
 | A6 | server04 `/dev/sde` silently unmonitored | Explicitly listed in `--smartctl.device` flags |

--- a/docs/infra-audit-2026-02.md
+++ b/docs/infra-audit-2026-02.md
@@ -220,7 +220,7 @@ Same as Security #14. Daily backup stays on the komodo LXC container with no off
 
 Alloy collects metrics from all Docker hosts but no dashboards are provisioned as code. Docker-specific views require manual creation.
 
-- Fix: Create a ConfigMap with a Docker hosts dashboard (node_exporter + cAdvisor, filtered by `source="docker"`).
+- Fix: Create a ConfigMap with a Docker hosts dashboard (node_exporter + cAdvisor, filtered by `source="infra"`).
 - Effort: Medium
 
 **14. Single age key with no rotation procedure documented**

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -165,7 +165,7 @@ In addition to the K8s Alloy DaemonSet, Grafana Alloy runs on all 6 Docker hosts
 - **Container metrics**: per-container resource usage via embedded cAdvisor
 - **Container logs**: stdout/stderr from all Docker containers
 
-Data is pushed to the K8s observability stack via the external write endpoints below. All Docker metrics include `source="docker"` and `instance=<hostname>` labels for filtering in Grafana.
+Data is pushed to the K8s observability stack via the external write endpoints below. All infrastructure host metrics include `source="infra"` and `instance=<hostname>` labels for filtering in Grafana.
 
 Alloy compose and config: `docker/stacks/shared/alloy/compose.yaml`
 Per-host credentials: `docker/stacks/shared/alloy/.sops.env` (SOPS-encrypted)

--- a/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -186,7 +186,7 @@ spec:
               - name: infra-node-health
                 rules:
                   - alert: InfraHostDown
-                    expr: up{job="integrations/unix", source="docker"} == 0
+                    expr: up{job="integrations/unix", source="infra"} == 0
                     for: 5m
                     labels:
                       severity: critical
@@ -194,8 +194,8 @@ spec:
                       summary: "Host {{ $labels.instance }} is unreachable"
                   - alert: FilesystemSpaceLow
                     expr: |
-                      (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="docker"}
-                      / node_filesystem_size_bytes{fstype!~"tmpfs|overlay",source="docker"}) > 0.85
+                      (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="infra"}
+                      / node_filesystem_size_bytes{fstype!~"tmpfs|overlay",source="infra"}) > 0.85
                     for: 15m
                     labels:
                       severity: warning
@@ -203,8 +203,8 @@ spec:
                       summary: "Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full"
                   - alert: FilesystemSpaceCritical
                     expr: |
-                      (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="docker"}
-                      / node_filesystem_size_bytes{fstype!~"tmpfs|overlay",source="docker"}) > 0.95
+                      (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="infra"}
+                      / node_filesystem_size_bytes{fstype!~"tmpfs|overlay",source="infra"}) > 0.95
                     for: 5m
                     labels:
                       severity: critical
@@ -213,7 +213,7 @@ spec:
                   - alert: FilesystemWillFillIn24h
                     expr: |
                       predict_linear(
-                        node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="docker"}[6h],
+                        node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",source="infra"}[6h],
                         24*3600
                       ) < 0
                     for: 1h
@@ -223,8 +223,8 @@ spec:
                       summary: "Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} will fill within 24 hours"
                   - alert: HighMemoryUsage
                     expr: |
-                      (1 - node_memory_MemAvailable_bytes{source="docker"}
-                      / node_memory_MemTotal_bytes{source="docker"}) > 0.90
+                      (1 - node_memory_MemAvailable_bytes{source="infra"}
+                      / node_memory_MemTotal_bytes{source="infra"}) > 0.90
                     for: 15m
                     labels:
                       severity: warning
@@ -233,7 +233,7 @@ spec:
                   - alert: HighCpuLoad
                     expr: |
                       (1 - avg by (instance)
-                      (rate(node_cpu_seconds_total{mode="idle",source="docker"}[10m]))) > 0.90
+                      (rate(node_cpu_seconds_total{mode="idle",source="infra"}[10m]))) > 0.90
                     for: 30m
                     labels:
                       severity: warning
@@ -306,21 +306,21 @@ spec:
               - name: infra-zfs-health
                 rules:
                   - alert: ZfsPoolDegraded
-                    expr: node_zfs_zpool_state{state="degraded", source="docker"} == 1
+                    expr: node_zfs_zpool_state{state="degraded", source="infra"} == 1
                     for: 5m
                     labels:
                       severity: critical
                     annotations:
                       summary: "ZFS pool {{ $labels.zpool }} is DEGRADED on {{ $labels.instance }}"
                   - alert: ZfsPoolFaulted
-                    expr: node_zfs_zpool_state{state="faulted", source="docker"} == 1
+                    expr: node_zfs_zpool_state{state="faulted", source="infra"} == 1
                     for: 1m
                     labels:
                       severity: critical
                     annotations:
                       summary: "ZFS pool {{ $labels.zpool }} is FAULTED on {{ $labels.instance }}"
                   - alert: ZfsPoolUnavail
-                    expr: node_zfs_zpool_state{state="unavail", source="docker"} == 1
+                    expr: node_zfs_zpool_state{state="unavail", source="infra"} == 1
                     for: 1m
                     labels:
                       severity: critical

--- a/kubernetes/apps/argocd-apps/apps/smartctl-exporter.yaml
+++ b/kubernetes/apps/argocd-apps/apps/smartctl-exporter.yaml
@@ -18,6 +18,8 @@ spec:
         serviceMonitor:
           enabled: true
           relabelings:
+            - sourceLabels: [__meta_kubernetes_endpoint_node_name]
+              targetLabel: instance
             - targetLabel: job
               replacement: smartctl
         tolerations:


### PR DESCRIPTION
## Summary
- Renamed `source="docker"` external label to `source="infra"` across all Alloy configs (shared, VPS override) and Prometheus alert rules to accurately describe infrastructure hosts managed outside K8s
- Added `__meta_kubernetes_endpoint_node_name` relabeling to smartctl-exporter ServiceMonitor so Talos instances show node names (talos01/02/03) instead of pod IPs
- Updated all 4 documentation files to reflect the label rename
- Updated remote Alloy configs on server04 and truenas via SSH and restarted services

## Files changed
- `docker/stacks/shared/alloy/compose.yaml` — label rename
- `docker/stacks/racknerd-aegis/alloy-override/compose.yaml` — label rename
- `kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml` — 12 alert rule selectors updated
- `kubernetes/apps/argocd-apps/apps/smartctl-exporter.yaml` — instance relabeling added
- `docs/hardware-monitoring-plan.md`, `docs/monitoring.md`, `docs/architecture.md`, `docs/infra-audit-2026-02.md` — doc updates

## Post-merge steps
1. Komodo sync + redeploy Alloy stacks on all 6 LAN hosts + VPS
2. Old `source="docker"` metrics will coexist with `source="infra"` until 3d retention flushes them

## Test plan
- [ ] After Komodo redeploy: `count by (source) (up{job="integrations/unix"})` shows `source="infra"`
- [ ] smartctl-exporter: `smartctl_device_smart_status{job="smartctl"}` shows `instance="talos01"` etc.
- [ ] Verify alerts: `ALERTS{alertname=~"Infra.*"}` — no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)