### PR TITLE
chore(docs): remove server04-alloy stack, update docs

### DIFF
--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -26,9 +26,11 @@ periphery/                 # Custom periphery Dockerfile + sops-decrypt.sh
 | nvr | 192.168.11.89 | root@nvr | frigate, nvr-alloy |
 | kasm | 192.168.11.34 | root@kasm | newt, kasm-alloy |
 | omni | 192.168.11.30 | root@omni | omni, omni-alloy |
-| server04 | 192.168.11.17 | mohitsharma44@server04 | traefik, vaultwarden, server04-alloy |
+| server04 | 192.168.11.17 | mohitsharma44@server04 | traefik, vaultwarden |
 | seaweedfs | 192.168.11.133 | mohitsharma44@seaweedfs | seaweedfs, seaweedfs-alloy |
-| racknerd-aegis | 23.94.73.98 | root@hs | aegis-gateway, aegis-pangolin, aegis-identity, aegis-periphery, aegis-newt, racknerd-aegis-alloy |
+| racknerd-aegis | 23.94.73.98 | root@hs | aegis-gateway, aegis-pangolin, aegis-identity, aegis-periphery, aegis-newt, aegis-pangolin-client, racknerd-aegis-alloy |
+
+**Note**: server04 monitoring uses a systemd Alloy service (not a Komodo-managed Docker stack). See `docs/hardware-monitoring-plan.md` for details.
 
 ## Komodo Access
 - **UI**: https://komodo.sharmamohit.com

--- a/docker/komodo-resources/stacks-server04.toml
+++ b/docker/komodo-resources/stacks-server04.toml
@@ -26,19 +26,3 @@ VAULTWARDEN_URL=bitwarden.sharmamohit.com
 [stack.config.pre_deploy]
 path = "docker/stacks/server04/vaultwarden"
 command = "sops-decrypt.sh"
-
-[[stack]]
-name = "server04-alloy"
-description = "Grafana Alloy monitoring agent for server04 host"
-tags = ["monitoring", "server04"]
-[stack.config]
-server_id = "server04"
-file_paths = ["docker/stacks/shared/alloy/compose.yaml"]
-repo = "mohitsharma44/homeops"
-branch = "main"
-environment = """
-INSTANCE_NAME=server04
-"""
-[stack.config.pre_deploy]
-path = "docker/stacks/shared/alloy"
-command = "sops-decrypt.sh"

--- a/docs/docker-hosts.md
+++ b/docs/docker-hosts.md
@@ -137,7 +137,8 @@ Primary application server and Docker build server for custom images.
 | Vaultwarden | `vaultwarden` | `bitwarden.sharmamohit.com` |
 | Vaultwarden Backup | `vaultwarden-backup` | Daily SQLite backup sidecar (02:00 UTC) |
 | Periphery | `komodo-periphery-periphery-1` | Also serves as Komodo build server |
-| Alloy | via Komodo stack | Host/container metrics and logs |
+| Alloy | systemd service | Host metrics + SMART + cAdvisor + Docker logs + journal. Config at `/etc/alloy/config.alloy` |
+| smartctl_exporter | systemd service | SMART disk health on `127.0.0.1:9633` (5 drives: 4 SAS via cciss + 1 SSD) |
 
 **Traefik network**: Services that need reverse proxying must join the `traefik_proxy` external Docker network and use Traefik labels for routing.
 

--- a/docs/hardware-monitoring-plan.md
+++ b/docs/hardware-monitoring-plan.md
@@ -71,8 +71,8 @@ pve (192.168.11.13)          truenas (192.168.11.15)       server04 (192.168.11.
 
 Note: komodo Alloy (LXC) and seaweedfs Alloy (VM) continue running the shared
 Docker compose config unchanged — they monitor their own guest-level metrics.
-server04's existing Komodo-managed Docker Alloy (server04-alloy stack) is
-REPLACED by the systemd Alloy and should be removed from stacks-server04.toml.
+server04's Komodo-managed Docker Alloy (server04-alloy stack) has been
+REPLACED by the systemd Alloy and removed from stacks-server04.toml.
 ```
 
 ---
@@ -289,7 +289,7 @@ All 5 drives are explicitly listed. When `--smartctl.device` flags are used, aut
 
 The `alloy` user must be added to the `docker` group for Docker socket access: `usermod -aG docker alloy`
 
-**Migration**: The existing `server04-alloy` Komodo stack (shared Docker Alloy) must be undeployed and removed from `docker/komodo-resources/stacks-server04.toml` after the systemd Alloy is confirmed working.
+**Migration**: The `server04-alloy` Komodo stack has been undeployed and removed from `docker/komodo-resources/stacks-server04.toml`. Systemd Alloy handles all monitoring on server04.
 
 **Config**: `/etc/alloy/config.alloy` — extends the pve/truenas config with Docker + IPMI blocks:
 
@@ -705,7 +705,7 @@ Phase 5 ───── ZFS pool health via truenas Alloy  ✅ DONE
 |------|---------|
 | `kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml` | Alertmanager config (api_url_file + secrets mount) + PrometheusRules |
 | `kubernetes/infrastructure/configs/kustomization.yaml` | Add alertmanager-slack-secret.yaml |
-| `docker/komodo-resources/stacks-server04.toml` | **Remove** `server04-alloy` stack (replaced by systemd) |
+| `docker/komodo-resources/stacks-server04.toml` | `server04-alloy` stack removed (replaced by systemd) |
 
 ### Manual steps (not GitOps)
 | Step | Host | Action |
@@ -719,11 +719,11 @@ Phase 5 ───── ZFS pool health via truenas Alloy  ✅ DONE
 | 7 | server04 | Install smartctl_exporter v0.13.0 binary + systemd service (listen: 127.0.0.1:9633, with cciss,N + /dev/sde flags) |
 | 8 | server04 | Install Alloy via Grafana APT repo + River config + env file with credentials |
 | 9 | server04 | Add alloy user to groups: `usermod -aG systemd-journal,docker alloy` |
-| 10 | server04 | Undeploy `server04-alloy` Komodo stack after systemd Alloy is confirmed working |
+| 10 | server04 | Undeploy `server04-alloy` Komodo stack — done, removed from stacks-server04.toml |
 | 11 | Slack | Create incoming webhook app, copy webhook URL for Alertmanager config |
 | 12 | HA | Create webhook automation for Alertmanager notifications |
 
-**Note**: komodo and seaweedfs Alloy stacks continue using the shared compose config unchanged — no overrides needed for those hosts. The `server04-alloy` stack is the only Komodo-managed Alloy that gets replaced.
+**Note**: komodo and seaweedfs Alloy stacks continue using the shared compose config unchanged — no overrides needed for those hosts.
 
 ### Credential Rotation Procedure
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -157,18 +157,18 @@ Grafana
 | Tempo OTLP HTTP | http://tempo.monitoring.svc:4318 |
 | Alertmanager | http://kube-prometheus-stack-alertmanager.monitoring.svc:9093 |
 
-## Docker Host Monitoring (Alloy via Komodo)
+## Infrastructure Host Monitoring (Alloy)
 
-In addition to the K8s Alloy DaemonSet, Grafana Alloy runs on all 6 Docker hosts (managed by [Komodo](/docker/README.md)). Each host collects:
+In addition to the K8s Alloy DaemonSet, Grafana Alloy runs on all infrastructure hosts outside K8s. Each host collects:
 
 - **Host metrics**: CPU, memory, disk, network via embedded node_exporter
-- **Container metrics**: per-container resource usage via embedded cAdvisor
-- **Container logs**: stdout/stderr from all Docker containers
+- **Container metrics**: per-container resource usage via embedded cAdvisor (Docker hosts only)
+- **Container logs**: stdout/stderr from all Docker containers (Docker hosts only)
 
 Data is pushed to the K8s observability stack via the external write endpoints below. All infrastructure host metrics include `source="infra"` and `instance=<hostname>` labels for filtering in Grafana.
 
-Alloy compose and config: `docker/stacks/shared/alloy/compose.yaml`
-Per-host credentials: `docker/stacks/shared/alloy/.sops.env` (SOPS-encrypted)
+**Komodo-managed Alloy** (5 LAN hosts + VPS): `docker/stacks/shared/alloy/compose.yaml`, credentials in `docker/stacks/shared/alloy/.sops.env`
+**Systemd Alloy** (server04, pve, truenas): `/etc/alloy/config.alloy`, credentials in `/etc/alloy/env`. These hosts also run smartctl_exporter and ship journal logs.
 
 ## External Write Endpoints
 


### PR DESCRIPTION
## Summary
- Removed `server04-alloy` Komodo stack definition from `stacks-server04.toml` (replaced by systemd Alloy during hardware monitoring rollout)
- Updated all documentation to reflect the migration: host tables, stack counts, deploy loops, monitoring descriptions
- Added missing `aegis-pangolin-client` to docker/CLAUDE.md host table
- Corrected Alloy deploy loop in docker/README.md (was deploying defunct server04-alloy, now includes racknerd-aegis-alloy)

## Post-merge steps
1. `km execute sync 'mohitsharma44/homeops'` — Komodo will delete the `server04-alloy` stack definition
2. Optionally clean up stopped container on server04: `ssh mohitsharma44@server04 "docker rm server04-alloy-alloy-1"`

## Test plan
- [ ] After sync: `km list stacks -a | grep server04` shows only traefik + vaultwarden
- [ ] server04 metrics still flowing: `up{instance="server04", source="infra"} == 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)