### PR TITLE
chore(deps): bump container image versions

### DIFF
--- a/docker/stacks/kasm/newt/compose.yaml
+++ b/docker/stacks/kasm/newt/compose.yaml
@@ -1,7 +1,7 @@
 services:
   newt:
     container_name: newt
-    image: fosrl/newt:1.7.0
+    image: fosrl/newt:1.10.1
     restart: unless-stopped
     env_file: .env
     environment:

--- a/docker/stacks/omni/omni/compose.yaml
+++ b/docker/stacks/omni/omni/compose.yaml
@@ -1,7 +1,7 @@
 services:
   omni:
     container_name: omni
-    image: ghcr.io/siderolabs/omni:v1.4.6
+    image: ghcr.io/siderolabs/omni:v1.5.8
     restart: always
     network_mode: host
     cap_add:

--- a/docker/stacks/racknerd-aegis/aegis-gateway/compose.yaml
+++ b/docker/stacks/racknerd-aegis/aegis-gateway/compose.yaml
@@ -31,7 +31,7 @@ services:
         max-file: "3"
 
   traefik:
-    image: traefik:v3.6.1
+    image: traefik:v3.6.9
     container_name: aegis-traefik
     restart: unless-stopped
     depends_on:

--- a/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
+++ b/docker/stacks/racknerd-aegis/alloy-override/compose.yaml
@@ -4,7 +4,7 @@
 # a complete standalone compose file. Keep service definition in sync with shared.
 services:
   alloy:
-    image: grafana/alloy:v1.13.1
+    image: grafana/alloy:v1.13.2
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker/stacks/racknerd-aegis/identity/compose.yaml
+++ b/docker/stacks/racknerd-aegis/identity/compose.yaml
@@ -1,6 +1,6 @@
 services:
   lldap:
-    image: lldap/lldap:stable
+    image: lldap/lldap:v0.6.2
     container_name: lldap
     restart: unless-stopped
     networks:
@@ -24,7 +24,7 @@ services:
         max-file: "3"
 
   pocketid:
-    image: ghcr.io/pocket-id/pocket-id:v2
+    image: ghcr.io/pocket-id/pocket-id:v2.3.0
     container_name: pocketid
     restart: unless-stopped
     networks:

--- a/docker/stacks/racknerd-aegis/newt/compose.yaml
+++ b/docker/stacks/racknerd-aegis/newt/compose.yaml
@@ -1,6 +1,6 @@
 services:
   newt:
-    image: fosrl/newt:1.9.0
+    image: fosrl/newt:1.10.1
     container_name: pangolin-newt
     restart: unless-stopped
     networks:

--- a/docker/stacks/racknerd-aegis/pangolin/compose.yaml
+++ b/docker/stacks/racknerd-aegis/pangolin/compose.yaml
@@ -1,6 +1,6 @@
 services:
   pangolin:
-    image: fosrl/pangolin:1.15.2
+    image: fosrl/pangolin:1.16.2
     container_name: pangolin
     restart: unless-stopped
     networks:
@@ -50,7 +50,7 @@ services:
         max-file: "3"
 
   traefik:
-    image: traefik:v3.6.1
+    image: traefik:v3.6.9
     container_name: pangolin-traefik
     restart: unless-stopped
     network_mode: service:gerbil

--- a/docker/stacks/seaweedfs/seaweedfs/compose.yaml
+++ b/docker/stacks/seaweedfs/seaweedfs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   master:
-    image: chrislusf/seaweedfs:4.06
+    image: chrislusf/seaweedfs:4.13
     container_name: seaweedfs-master
     restart: unless-stopped
     ports:
@@ -38,7 +38,7 @@ services:
       - "no-new-privileges:true"
 
   volume:
-    image: chrislusf/seaweedfs:4.06
+    image: chrislusf/seaweedfs:4.13
     container_name: seaweedfs-volume
     restart: unless-stopped
     ports:
@@ -81,7 +81,7 @@ services:
       - "no-new-privileges:true"
 
   filer:
-    image: chrislusf/seaweedfs:4.06
+    image: chrislusf/seaweedfs:4.13
     container_name: seaweedfs-filer
     restart: unless-stopped
     ports:
@@ -123,7 +123,7 @@ services:
       - "no-new-privileges:true"
 
   s3:
-    image: chrislusf/seaweedfs:4.06
+    image: chrislusf/seaweedfs:4.13
     container_name: seaweedfs-s3
     restart: unless-stopped
     ports:
@@ -160,7 +160,7 @@ services:
       - "no-new-privileges:true"
 
   webdav:
-    image: chrislusf/seaweedfs:4.06
+    image: chrislusf/seaweedfs:4.13
     container_name: seaweedfs-webdav
     restart: unless-stopped
     ports:

--- a/docker/stacks/server04/vaultwarden/compose.yaml
+++ b/docker/stacks/server04/vaultwarden/compose.yaml
@@ -1,6 +1,6 @@
 services:
   vaultwarden:
-    image: vaultwarden/server:1.34.1
+    image: vaultwarden/server:1.35.4
     container_name: vaultwarden
     restart: always
     security_opt:

--- a/docker/stacks/shared/alloy/compose.yaml
+++ b/docker/stacks/shared/alloy/compose.yaml
@@ -3,7 +3,7 @@
 # `environment` field in each host's stack TOML definition.
 services:
   alloy:
-    image: grafana/alloy:v1.13.1
+    image: grafana/alloy:v1.13.2
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/kubernetes/apps/argocd-apps/apps/newt.yaml
+++ b/kubernetes/apps/argocd-apps/apps/newt.yaml
@@ -15,7 +15,7 @@ spec:
       valuesObject:
         global:
           image:
-            tag: "1.9.0"
+            tag: "1.10.1"
         newtInstances:
           - name: homelab-k8s
             enabled: true


### PR DESCRIPTION
## Summary

- 🔴 **Security** — Vaultwarden `1.34.1 → 1.35.4` (3 CVEs: org member collection access bypass)
- 🔴 **Security** — Traefik `v3.6.1 → v3.6.9` on racknerd-aegis (2 CVEs fixed in v3.6.8)
- 🟡 Newt `1.7.0/1.9.0 → 1.10.1` (kasm, racknerd-aegis, k8s/argocd) — no migration steps
- 🟡 Pangolin `1.15.2 → 1.16.2` — adds SSH tunneling, no breaking changes
- 🟢 Grafana Alloy `v1.13.1 → v1.13.2` — patch only, both shared + alloy-override
- 🟢 SeaweedFS `4.06 → 4.13` — all 5 services, no migration steps
- 🟢 Omni `v1.4.6 → v1.5.8` — `--sqlite-storage-path` already present
- 🟢 lldap `stable → v0.6.2` — pinning floating tag
- 🟢 pocket-id `v2 → v2.3.0` — pinning floating tag

## Skipped

**Traefik v3.0 → v3.6.9 on server04** — Requires migration review across 6 minor versions (X-Forwarded-Prefix behavior, WebSocket GODEBUG workaround, defaultRuleSyntax deprecation, health check path validation). Tracked separately.

## Test plan

- [ ] Komodo sync picks up all changed stacks
- [ ] Vaultwarden redeploys and vault login works
- [ ] Pangolin/Newt tunnel connectivity verified (all 3 Newt instances)
- [ ] Alloy metrics/logs still flowing in Grafana
- [ ] SeaweedFS S3/WebDAV healthy after upgrade
- [ ] Omni UI accessible after upgrade
- [ ] lldap / PocketID auth still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)