### PR TITLE
fix(server04): bump traefik v3.0→v3.6.9 and remove stale vaultwarden websocket router

### DIFF
--- a/docker/stacks/server04/traefik/compose.yaml
+++ b/docker/stacks/server04/traefik/compose.yaml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: traefik:v3.0
+    image: traefik:v3.6.9
     container_name: traefik
     restart: always
     security_opt:

--- a/docker/stacks/server04/vaultwarden/compose.yaml
+++ b/docker/stacks/server04/vaultwarden/compose.yaml
@@ -26,9 +26,6 @@ services:
       - traefik.http.routers.bitwarden-ui.rule=Host(`bitwarden.sharmamohit.com`)
       - traefik.http.routers.bitwarden-ui.service=bitwarden-ui
       - traefik.http.services.bitwarden-ui.loadbalancer.server.port=80
-      - traefik.http.routers.bitwarden-websocket.rule=Host(`bitwarden.sharmamohit.com`) && Path(`/notifications/hub`)
-      - traefik.http.routers.bitwarden-websocket.service=bitwarden-websocket
-      - traefik.http.services.bitwarden-websocket.loadbalancer.server.port=3012
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Summary

- Traefik `v3.0 → v3.6.9` on server04 — includes 2 CVE fixes from v3.6.8
- Remove stale Vaultwarden WebSocket router targeting port 3012

## Why no migration steps needed

Server04 Traefik is Docker-only with a minimal config (one backend: Vaultwarden). None of the v3.x breaking changes apply:
- No Kubernetes providers
- No `X-Forwarded-Prefix` reliance
- No HTTP/2 backends (no `GODEBUG` needed)
- No `defaultRuleSyntax` set
- No `healthCheck.path` with absolute URLs

## Vaultwarden WebSocket cleanup

Port 3012 was **hard-removed in Vaultwarden v1.31.0**. WebSocket notifications (`/notifications/hub`) have been unified onto the main port 80 since v1.29.0. The separate router was pointing at a port that no longer exists — all WebSocket traffic now flows through the existing `bitwarden-ui` router on port 80.

## Test plan

- [ ] Traefik redeploys cleanly on server04
- [ ] `bitwarden.sharmamohit.com` loads and login works
- [ ] Bitwarden client WebSocket notifications still work (check for real-time sync between clients)
- [ ] `traefik.sharmamohit.com/dashboard` still accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)