### PR TITLE
feat(proxmox): add Ansible IaC for R720XD Proxmox node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         entry: encrypt-sops-files.sh
         language: script
         types: [file]
-        files: (secret\.yaml|\.sops\.(env|json))$
+        files: (secret\.yaml|\.sops\.(env|json|yml))$
 
   - repo: https://github.com/onedr0p/sops-pre-commit
     rev: v2.1.1

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,4 +1,7 @@
 creation_rules:
+  # Proxmox/Ansible secrets (encrypt all values in .sops.yml files)
+  - path_regex: proxmox/.*\.sops\.yml$
+    age: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
   # Docker/Komodo secrets (encrypt entire .sops.env and .sops.json files)
   - path_regex: docker/stacks/.*\.sops\.(env|json)$
     age: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Claude Code Instructions - Homeops Repository
 
 ## What This Repo Is
-GitOps repository for homelab infrastructure. Manages both **Kubernetes** (Flux + ArgoCD) and **Docker** containers (Komodo GitOps) from a single repo with unified secret management (SOPS + age).
+GitOps repository for homelab infrastructure. Manages **Kubernetes** (Flux + ArgoCD), **Docker** containers (Komodo GitOps), and **Proxmox** nodes (Ansible) from a single repo with unified secret management (SOPS + age).
 
 Docker/Komodo-specific instructions are in `docker/CLAUDE.md` (loaded automatically when working in `docker/`).
 
@@ -9,6 +9,7 @@ Docker/Komodo-specific instructions are in `docker/CLAUDE.md` (loaded automatica
 ```
 Kubernetes: Git Push → Flux Reconciles → Infrastructure Ready → ArgoCD Deploys Apps
 Docker:     Git Push → Komodo ResourceSync → pre_deploy (SOPS decrypt) → docker compose up
+Proxmox:    ansible-playbook proxmox/site.yml → lae.proxmox role + custom tasks
 ```
 
 Kubernetes deployment chain (`kubernetes/clusters/minipcs/`):
@@ -28,6 +29,13 @@ kubernetes/
     ├── argocd-apps/apps/  # ArgoCD Application manifests go HERE
     └── minipcs/           # Flux overlay (deploys argocd + root-app)
 docker/                    # Docker infrastructure (Komodo GitOps) — see docker/CLAUDE.md
+proxmox/                   # Proxmox node config (Ansible + lae.proxmox role)
+├── site.yml               # Main playbook
+├── inventory/hosts.yml    # R720XD standalone node
+├── group_vars/all/
+│   ├── vars.yml           # Non-secret config
+│   └── secrets.sops.yml   # SOPS-encrypted credentials
+└── templates/             # Alloy, Sanoid, smartctl-exporter configs
 ```
 
 ## Key Files to Read First
@@ -38,13 +46,14 @@ docker/                    # Docker infrastructure (Komodo GitOps) — see docke
 
 ## Secrets (SOPS + age)
 
-Both K8s and Docker use the same SOPS + age key pair.
+K8s, Docker, and Proxmox all use the same SOPS + age key pair.
 
 - Config: `.sops.yaml` at repo root
 - Public key: `age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk`
 - Private key: `~/.sops/key.txt` (local), `/etc/sops/age/keys.txt` (Docker hosts), `sops-age` secret (K8s)
 - K8s: `*secret.yaml` — Flux decrypts in-cluster
 - Docker: `.sops.env`/`.sops.json` next to compose files — Periphery decrypts at deploy time
+- Proxmox: `*.sops.yml` in `proxmox/group_vars/` — `community.sops` Ansible plugin decrypts at playbook runtime
 - Never commit unencrypted secrets (pre-commit hooks block this)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Homeops
 
-GitOps repository for homelab infrastructure. Manages both **Kubernetes** (via Flux + ArgoCD) and **Docker** containers (via Komodo) from a single repo with unified secret management (SOPS + age).
+GitOps repository for homelab infrastructure. Manages **Kubernetes** (via Flux + ArgoCD), **Docker** containers (via Komodo), and **Proxmox** nodes (via Ansible) from a single repo with unified secret management (SOPS + age).
 
 ## Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                          homeops (this repo)                            │
-├─────────────────────────────────┬───────────────────────────────────────┤
-│   Kubernetes (Flux + ArgoCD)    │       Docker (Komodo GitOps)          │
-│                                 │                                       │
-│   3-node K8s cluster (minipcs)  │   6 Docker hosts                      │
-│   Infrastructure: MetalLB,      │   Hosts: komodo, nvr, kasm,           │
-│     Ingress, Cert-Manager,      │     omni, server04, seaweedfs         │
-│     Rook-Ceph                   │   13 stacks across all hosts          │
-│   Apps: Monitoring stack        │   Monitoring: Alloy on every host     │
-│     (Prometheus, Thanos, Loki,  │   Secrets: SOPS + age (pre_deploy)    │
-│     Tempo, Alloy, Grafana)      │                                       │
-├─────────────────────────────────┴───────────────────────────────────────┤
-│   Shared: SOPS + age encryption, *.sharmamohit.com domain,             │
-│           pre-commit hooks, observability (all telemetry → Grafana)     │
+├──────────────────┬──────────────────────┬────────────────────────────────┤
+│  Kubernetes      │  Docker              │  Proxmox                       │
+│  (Flux + ArgoCD) │  (Komodo GitOps)     │  (Ansible)                     │
+│                  │                      │                                │
+│  3-node cluster  │  6 Docker hosts      │  R720XD standalone node        │
+│  Infrastructure: │  komodo, nvr, kasm,  │  ZFS storage (pool0, ssdpool0) │
+│   MetalLB,       │  omni, server04,     │  SeaweedFS VM (S3/WebDAV)      │
+│   Ingress,       │  seaweedfs           │  NFS exports, Sanoid snapshots │
+│   Cert-Manager,  │  13 stacks           │  Alloy + smartctl monitoring   │
+│   Rook-Ceph      │                      │                                │
+├──────────────────┴──────────────────────┴────────────────────────────────┤
+│  Shared: SOPS + age encryption, *.sharmamohit.com domain,               │
+│          pre-commit hooks, observability (all telemetry → Grafana)       │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -42,6 +42,11 @@ GitOps repository for homelab infrastructure. Manages both **Kubernetes** (via F
 │   ├── komodo-resources/       # TOML resource declarations
 │   ├── stacks/                 # Compose files + SOPS-encrypted secrets
 │   └── periphery/              # Custom periphery image (SOPS + age)
+├── proxmox/                    # Proxmox node config (Ansible)
+│   ├── site.yml                # Main playbook (lae.proxmox + NFS + Sanoid + monitoring)
+│   ├── inventory/hosts.yml     # R720XD at 192.168.11.15
+│   ├── group_vars/all/         # vars.yml + secrets.sops.yml
+│   └── templates/              # Alloy, Sanoid, smartctl-exporter configs
 └── docs/                       # Additional documentation
     ├── ceph.md                 # Rook-Ceph storage
     ├── monitoring.md           # Observability stack architecture
@@ -129,6 +134,26 @@ Manages Docker containers across 6 hosts via [Komodo](https://komo.do) Resource 
 4. Secrets are SOPS-encrypted `.sops.env` files decrypted at deploy time by a custom periphery image (komodo host uses systemd Periphery with native sops+age)
 5. Alloy monitoring runs on every host, pushing metrics/logs to the K8s observability stack
 
+## Proxmox (Ansible)
+
+Manages Proxmox VE node configuration via Ansible. See [proxmox/README.md](proxmox/README.md).
+
+### Node: R720XD (standalone)
+
+| Property | Value |
+|----------|-------|
+| **IP** | 192.168.11.15 |
+| **Hardware** | Dell R720XD, 256GB RAM, 14 drives |
+| **ZFS Pools** | pool0 (21.8T raidz1), ssdpool0 (7.27T raidz1) — both encrypted (aes-256-gcm) |
+| **VMs** | SeaweedFS (S3 object storage, 4 buckets) |
+| **Services** | NFS export (/mnt/pool0/nvr for Frigate), Sanoid snapshots, Alloy, smartctl-exporter |
+
+```bash
+cd proxmox
+ansible-galaxy install -r requirements.yml
+ansible-playbook site.yml
+```
+
 ## Observability
 
 Full metrics, logs, and traces stack. See [docs/monitoring.md](docs/monitoring.md) for architecture, data flow, and retention policies.
@@ -169,6 +194,7 @@ Both Kubernetes and Docker secrets use the same SOPS + age encryption with the s
 |-------|--------------|------------|
 | **Kubernetes** | `*secret.yaml` (encrypts `data`/`stringData` fields) | Flux decrypts in-cluster via `sops-age` secret |
 | **Docker** | `.sops.env`, `.sops.json` (encrypts entire file) | Periphery agent decrypts at deploy time via `pre_deploy` hook |
+| **Proxmox** | `*.sops.yml` (encrypts all values) | `community.sops` Ansible vars plugin decrypts at playbook runtime |
 
 **Key:**
 - Public: `age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk`

--- a/encrypt-sops-files.sh
+++ b/encrypt-sops-files.sh
@@ -6,7 +6,7 @@ for file in "$@"; do
 	if [[ -f "$file" ]]; then
 		if ! grep -q 'ENC\[[A-Z0-9_]*,data:.*,type:.*\]' "$file"; then
 			echo "File $file is not encrypted, encrypting..."
-			if [[ "$file" =~ \.yaml ]]; then
+			if [[ "$file" =~ \.(yaml|yml) ]]; then
 				sops --encrypt --in-place --input-type=yaml "$file" || EXIT_CODE=1
 			elif [[ "$file" =~ \.json ]]; then
 				sops --encrypt --in-place --input-type=json "$file" || EXIT_CODE=1

--- a/proxmox/.gitignore
+++ b/proxmox/.gitignore
@@ -1,0 +1,2 @@
+# Ansible retry files
+*.retry

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -1,0 +1,189 @@
+# Proxmox VE Ansible Playbook
+
+Automated configuration for Proxmox VE nodes (currently R720XD standalone) using Ansible and the [lae.proxmox](https://github.com/lae/ansible-role-proxmox) role.
+
+## What Gets Configured
+
+- **Base Proxmox VE setup** via `lae.proxmox` role:
+  - APT repositories (no-subscription)
+  - ZFS configuration and optimization
+  - Storage backends (ZFS pools)
+  - Users, groups, and ACLs
+  - Datacenter settings
+
+- **Infrastructure components:**
+  - NFS exports (for NVR data sharing)
+  - Sanoid (ZFS snapshot automation)
+  - Alloy (Grafana observability agent)
+  - smartctl-exporter (SMART disk health metrics)
+
+## Prerequisites
+
+1. Fresh Proxmox VE installation (8.0+)
+2. ZFS pools already imported (e.g., `pool0`, `ssdpool0`)
+3. Ansible 2.10+ installed on control machine
+4. SSH access as `root` to the Proxmox host
+5. Python 3 available on the Proxmox host
+
+## Quick Start
+
+### 1. Install Role Dependencies
+
+```bash
+ansible-galaxy install -r requirements.yml
+```
+
+### 2. Secrets (SOPS + age)
+
+Secrets are managed via SOPS + age — the same mechanism used for K8s and Docker secrets in this repo. The `community.sops` Ansible collection auto-decrypts `*.sops.yml` files in `group_vars/`.
+
+Secrets file: `group_vars/all/secrets.sops.yml`
+
+```bash
+# View secrets
+sops -d group_vars/all/secrets.sops.yml
+
+# Edit secrets
+sops group_vars/all/secrets.sops.yml
+```
+
+Non-secret config (URLs, instance names, retention policies) lives in `group_vars/all/vars.yml`.
+
+### 3. Run the Playbook
+
+```bash
+ansible-playbook site.yml
+```
+
+## Inventory
+
+Edit `inventory/hosts.yml` to add/modify Proxmox nodes:
+
+```yaml
+all:
+  hosts:
+    r720xd:
+      ansible_host: 192.168.11.15
+      ansible_user: root
+      ansible_python_interpreter: /usr/bin/python3
+```
+
+## Variables
+
+### Non-Secret (group_vars/all/vars.yml)
+
+- `pve_group` - Proxmox group name (required by lae.proxmox)
+- `pve_cluster_enabled` - Enable clustering (false for standalone)
+- `pve_repository` - APT repository configuration
+- `pve_zfs_enabled` - Enable ZFS support
+- `pve_zfs_options` - ZFS tuning (ARC cache size)
+- `pve_storages` - Storage backend definitions
+- `pve_users`, `pve_groups`, `pve_acls` - User and permissions
+- `nfs_exports` - NFS export paths and options
+- `sanoid_datasets` - ZFS datasets to snapshot
+- `smartctl_exporter_*` - SMART exporter configuration
+- `alloy_instance_name` - Node name for metrics labels
+
+### Secrets (group_vars/all/secrets.sops.yml — SOPS encrypted)
+
+- `vault_alloy_basic_auth_username` - Basic auth username for Prometheus/Loki
+- `vault_alloy_basic_auth_password` - Basic auth password
+
+## Customization
+
+### Adding Storage Backends
+
+Edit `group_vars/all/vars.yml`:
+
+```yaml
+pve_storages:
+  - name: pool0-store
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: pool0
+```
+
+### Modifying Snapshot Retention
+
+Edit `group_vars/all/vars.yml` under `sanoid_templates`:
+
+```yaml
+sanoid_templates:
+  data_retention:
+    hourly: 24
+    daily: 30
+    weekly: 4
+    monthly: 12
+```
+
+### Adding Users/ACLs
+
+Edit `group_vars/all/vars.yml`:
+
+```yaml
+pve_users:
+  - name: ops@pve
+    email: ops@example.com
+
+pve_acls:
+  - path: /vms
+    roles: ["PVEVMUser"]
+    users: ["ops@pve"]
+```
+
+## Troubleshooting
+
+### Connection issues
+
+Verify SSH access:
+
+```bash
+ssh -i /path/to/key root@192.168.11.15
+```
+
+### SOPS decryption issues
+
+Ensure the age private key is at `~/.sops/key.txt`:
+
+```bash
+ls -la ~/.sops/key.txt
+sops -d group_vars/all/secrets.sops.yml  # test decryption
+```
+
+### Role installation problems
+
+Clear cache and reinstall:
+
+```bash
+rm -rf ~/.ansible/roles/*
+ansible-galaxy install -r requirements.yml --force
+```
+
+## Monitoring
+
+Once deployed, metrics flow to:
+
+- **Prometheus**: `https://prometheus.sharmamohit.com`
+- **Loki**: `https://loki.sharmamohit.com`
+
+Dashboards and alerts can reference labels:
+- `instance=r720xd` (hostname)
+- `source=infra` (infrastructure origin)
+- `job=node|smartctl|journal` (metric job type)
+
+## Files
+
+- `site.yml` - Main playbook
+- `requirements.yml` - Galaxy role dependencies
+- `ansible.cfg` - Ansible configuration
+- `inventory/hosts.yml` - Host inventory
+- `group_vars/all/vars.yml` - Non-secret variables
+- `group_vars/all/secrets.sops.yml` - SOPS-encrypted secrets (same age key as K8s/Docker)
+- `templates/` - Jinja2 configuration templates
+
+## References
+
+- [lae.proxmox role](https://github.com/lae/ansible-role-proxmox)
+- [Proxmox VE docs](https://pve.proxmox.com/wiki/)
+- [Sanoid documentation](https://github.com/jimsalterjrs/sanoid)
+- [Alloy documentation](https://grafana.com/docs/alloy/)

--- a/proxmox/ansible.cfg
+++ b/proxmox/ansible.cfg
@@ -1,0 +1,16 @@
+[defaults]
+inventory = inventory/hosts.yml
+roles_path = ~/.ansible/roles
+host_key_checking = false
+retry_files_enabled = false
+
+# SOPS vars plugin auto-decrypts *.sops.yml files in group_vars/host_vars
+vars_plugins_enabled = host_group_vars,community.sops.sops
+
+[community.sops]
+# Use age key at ~/.sops/key.txt (same as K8s/Docker SOPS setup)
+age_keyfile = ~/.sops/key.txt
+
+[privilege_escalation]
+become = true
+become_method = sudo

--- a/proxmox/ansible.cfg
+++ b/proxmox/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 inventory = inventory/hosts.yml
 roles_path = ~/.ansible/roles
-host_key_checking = false
 retry_files_enabled = false
 
 # SOPS vars plugin auto-decrypts *.sops.yml files in group_vars/host_vars
@@ -10,7 +9,3 @@ vars_plugins_enabled = host_group_vars,community.sops.sops
 [community.sops]
 # Use age key at ~/.sops/key.txt (same as K8s/Docker SOPS setup)
 age_keyfile = ~/.sops/key.txt
-
-[privilege_escalation]
-become = true
-become_method = sudo

--- a/proxmox/group_vars/all/secrets.sops.yml
+++ b/proxmox/group_vars/all/secrets.sops.yml
@@ -1,0 +1,17 @@
+vault_alloy_basic_auth_username: ENC[AES256_GCM,data:nGriDhA=,iv:gm+tUyXKIADITuQOLZu8mmbve3so2/jGmhgnuV3lROQ=,tag:Oj0bAaS1136S9EiG1QnmjQ==,type:str]
+vault_alloy_basic_auth_password: ENC[AES256_GCM,data:4eb5BJ5HIF1MQttg7ZRC+jxBW8mKxexk65yl23n0hEMbrpkpmeNH4NZGqw==,iv:XuTsBntX+Rw4CdtX9niLPvaz2RIXKf+lEU8UyK/s62w=,tag:4uXhnousXKV2P2GWBbqEPw==,type:str]
+sops:
+    age:
+        - recipient: age1y6dnshya496nf3072zudw3vd33723v02g3tfvpt563zng0xd9ghqwzj5xk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTQUR1a0w2UmVVdjhwRFlJ
+            ZlNIZmNjTGhtK3NlQ0duSTBzemxnd1FKdG1JClQ1UDQ0N3VEbFNQeVNkaVJqekNl
+            VjBsand4K0ZGZldub3M5RzVkZWpRZGcKLS0tIHcrL1dpL3V0VzVBRTlpMkJyNEVU
+            OW5jT1lBUUJyY1VLeW9LYlB5T09YQzAKJbmq9Es0oLw+kt4F6ZWa0Vaj0d4UCvmP
+            4G3P9YTqzmQL4DP+6KuJBnyKYwcuzQiKjqWhsFyasX/ktDMNSOg/mg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-03-15T18:57:23Z"
+    mac: ENC[AES256_GCM,data:pyUHQ/t0FM1nCFIhSem6eC5JabZJDHYGW4uiSU9xcDScNABeq4xtu3X09XPVxwKwsH4QU9NZFzkMZBOtcA+dF9i4fgvmcsoVTO7PQKxCXMDX44Hni5cGNxgLBClNhwIhbxqZUgBp2pEmQKiN/HgJ3FzxAhQUDkENQ4W72K1uKqw=,iv:f3ul3tXypa6PyKx4WGs0H1gFUHkTtmflfw+erBS8KXU=,tag:cH1HqPDSGJQCCVvhN6UGWA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/proxmox/group_vars/all/vars.yml
+++ b/proxmox/group_vars/all/vars.yml
@@ -85,6 +85,7 @@ alloy_instance_name: "r720xd"
 alloy_prometheus_url: "https://prometheus.sharmamohit.com/api/v1/write"
 alloy_loki_url: "https://loki.sharmamohit.com/loki/api/v1/push"
 smartctl_exporter_version: "0.14.0"
+smartctl_exporter_checksum: "875983cd27affc5a682401930e5a8eea3f06c325fe6d6a7228c5547d882685b3"
 smartctl_exporter_listen: "127.0.0.1:9633"
 smartctl_exporter_interval: "120s"
 

--- a/proxmox/group_vars/all/vars.yml
+++ b/proxmox/group_vars/all/vars.yml
@@ -36,6 +36,25 @@ pve_storages:
     pool: ssdpool0
     sparse: true
 
+  - name: local-ssd
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: local-ssd
+    sparse: true
+
+# ── Local SSD Pool (VM/LXC storage) ────────────────
+# ZFS mirror on 2x Samsung 870 EVO 1TB (was TrueNAS ssdpool1)
+local_ssd_pool:
+  name: local-ssd
+  vdev: mirror
+  drives:
+    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909545W
+    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909519P
+  properties:
+    ashift: 12
+    compression: lz4
+    atime: "off"
+
 # ── Users ───────────────────────────────────────────
 pve_groups:
   - name: ops

--- a/proxmox/group_vars/all/vars.yml
+++ b/proxmox/group_vars/all/vars.yml
@@ -1,0 +1,90 @@
+---
+# Proxmox VE Configuration - R720XD Standalone Node
+# Uses lae.proxmox role for base configuration
+
+# ── Core ────────────────────────────────────────────
+pve_group: all
+pve_cluster_enabled: no
+
+# ── Repository (no-subscription) ────────────────────
+pve_repository:
+  uris: http://download.proxmox.com/debian/pve
+  suites: "{{ ansible_distribution_release }}"
+  components: pve-no-subscription
+pve_remove_subscription_warning: true
+pve_run_proxmox_upgrades: true
+pve_check_for_kernel_update: true
+pve_reboot_on_kernel_update: false
+
+# ── ZFS ─────────────────────────────────────────────
+pve_zfs_enabled: yes
+# 192GB ARC max (leaves 64GB for VMs/system out of 256GB total)
+pve_zfs_options: "zfs_arc_max=206158430208"
+
+# ── Storage Backends ────────────────────────────────
+# Pools must already be imported before running this playbook
+pve_storages:
+  - name: pool0-store
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: pool0
+    sparse: true
+
+  - name: ssdpool0-store
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: ssdpool0
+    sparse: true
+
+# ── Users ───────────────────────────────────────────
+pve_groups:
+  - name: ops
+    comment: Operations
+
+pve_users:
+  - name: root@pam
+    email: mohitsharma44@gmail.com
+
+pve_acls:
+  - path: /
+    roles: ["Administrator"]
+    groups: ["ops"]
+
+# ── Datacenter ──────────────────────────────────────
+pve_datacenter_cfg:
+  keyboard: en-us
+
+# ── NFS Export ──────────────────────────────────────
+# Not handled by lae.proxmox role — configured in site.yml tasks
+nfs_exports:
+  - path: /mnt/pool0/nvr
+    network: "192.168.11.0/24"
+    options: "rw,sync,no_subtree_check,no_root_squash"
+
+# ── Monitoring ──────────────────────────────────────
+alloy_instance_name: "r720xd"
+alloy_prometheus_url: "https://prometheus.sharmamohit.com/api/v1/write"
+alloy_loki_url: "https://loki.sharmamohit.com/loki/api/v1/push"
+smartctl_exporter_version: "0.14.0"
+smartctl_exporter_listen: "127.0.0.1:9633"
+smartctl_exporter_interval: "120s"
+
+# ── Sanoid (ZFS snapshots) ──────────────────────────
+sanoid_datasets:
+  - name: "pool0/nvr"
+    template: data_retention
+    recursive: yes
+  - name: "ssdpool0"
+    template: data_retention
+    recursive: yes
+
+sanoid_templates:
+  data_retention:
+    frequently: 0
+    hourly: 24
+    daily: 30
+    weekly: 4
+    monthly: 12
+    yearly: 2
+    autosnap: yes
+    autoprune: yes

--- a/proxmox/inventory/hosts.yml
+++ b/proxmox/inventory/hosts.yml
@@ -1,0 +1,7 @@
+---
+all:
+  hosts:
+    r720xd:
+      ansible_host: 192.168.11.15
+      ansible_user: root
+      ansible_python_interpreter: /usr/bin/python3

--- a/proxmox/requirements.yml
+++ b/proxmox/requirements.yml
@@ -5,4 +5,4 @@ roles:
 
 collections:
   - name: community.sops
-    version: ">=1.9.0"
+    version: "1.9.2"

--- a/proxmox/requirements.yml
+++ b/proxmox/requirements.yml
@@ -1,0 +1,8 @@
+---
+roles:
+  - name: lae.proxmox
+    version: "v1.10.1"
+
+collections:
+  - name: community.sops
+    version: ">=1.9.0"

--- a/proxmox/site.yml
+++ b/proxmox/site.yml
@@ -1,0 +1,219 @@
+---
+- name: Configure Proxmox VE on R720XD
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Wait for SSH to become available
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+
+    - name: Gather facts
+      ansible.builtin.setup:
+
+  roles:
+    - role: lae.proxmox
+
+  tasks:
+    # ── NFS Export ────────────────────────────────────
+    - name: Install NFS kernel server
+      ansible.builtin.apt:
+        name:
+          - nfs-kernel-server
+          - nfs-common
+        state: present
+
+    - name: Configure NFS exports
+      ansible.builtin.lineinfile:
+        path: /etc/exports
+        line: "{{ item.path }} {{ item.network }}({{ item.options }})"
+        regexp: "^{{ item.path | regex_escape }}\\s"
+        create: yes
+      loop: "{{ nfs_exports }}"
+      notify: reload nfs exports
+
+    - name: Enable and start NFS server
+      ansible.builtin.systemd:
+        name: nfs-kernel-server
+        state: started
+        enabled: yes
+
+    # ── Sanoid (ZFS Snapshots) ────────────────────────
+    - name: Install Sanoid
+      ansible.builtin.apt:
+        name: sanoid
+        state: present
+
+    - name: Ensure Sanoid config directory exists
+      ansible.builtin.file:
+        path: /etc/sanoid
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Deploy Sanoid config
+      ansible.builtin.template:
+        src: sanoid.conf.j2
+        dest: /etc/sanoid/sanoid.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart sanoid timer
+
+    - name: Enable Sanoid timers
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: started
+        enabled: yes
+      loop:
+        - sanoid.timer
+
+    # ── Grafana APT Repository ────────────────────────
+    - name: Ensure keyrings directory exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Download Grafana GPG key
+      ansible.builtin.get_url:
+        url: https://apt.grafana.com/gpg.key
+        dest: /tmp/grafana-gpg.key
+        mode: "0644"
+
+    - name: Dearmor and install Grafana GPG key
+      ansible.builtin.shell:
+        cmd: gpg --dearmor < /tmp/grafana-gpg.key > /etc/apt/keyrings/grafana.gpg
+        creates: /etc/apt/keyrings/grafana.gpg
+
+    - name: Add Grafana APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main"
+        filename: grafana
+        state: present
+        update_cache: yes
+
+    # ── Alloy ─────────────────────────────────────────
+    - name: Install Alloy
+      ansible.builtin.apt:
+        name: alloy
+        state: present
+
+    - name: Deploy Alloy config
+      ansible.builtin.template:
+        src: alloy-config.alloy.j2
+        dest: /etc/alloy/config.alloy
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart alloy
+
+    - name: Deploy Alloy environment file
+      ansible.builtin.template:
+        src: alloy-env.j2
+        dest: /etc/default/alloy-env
+        owner: root
+        group: root
+        mode: "0600"
+      notify: restart alloy
+
+    - name: Ensure Alloy systemd override directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/alloy.service.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Configure Alloy systemd override for env file
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/alloy.service.d/override.conf
+        content: |
+          [Service]
+          EnvironmentFile=/etc/default/alloy-env
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - daemon reload
+        - restart alloy
+
+    - name: Enable and start Alloy
+      ansible.builtin.systemd:
+        name: alloy
+        state: started
+        enabled: yes
+
+    # ── smartctl-exporter ─────────────────────────────
+    - name: Install smartmontools
+      ansible.builtin.apt:
+        name: smartmontools
+        state: present
+
+    - name: Download smartctl_exporter
+      ansible.builtin.get_url:
+        url: "https://github.com/prometheus-community/smartctl_exporter/releases/download/v{{ smartctl_exporter_version }}/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64.tar.gz"
+        dest: /tmp/smartctl_exporter.tar.gz
+
+    - name: Extract smartctl_exporter
+      ansible.builtin.unarchive:
+        src: /tmp/smartctl_exporter.tar.gz
+        dest: /tmp/
+        remote_src: yes
+
+    - name: Install smartctl_exporter binary
+      ansible.builtin.copy:
+        src: "/tmp/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64/smartctl_exporter"
+        dest: /usr/local/bin/smartctl_exporter
+        owner: root
+        group: root
+        mode: "0755"
+        remote_src: yes
+      notify: restart smartctl-exporter
+
+    - name: Deploy smartctl-exporter systemd service
+      ansible.builtin.template:
+        src: smartctl-exporter.service.j2
+        dest: /etc/systemd/system/smartctl-exporter.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - daemon reload
+        - restart smartctl-exporter
+
+    - name: Enable and start smartctl-exporter
+      ansible.builtin.systemd:
+        name: smartctl-exporter
+        state: started
+        enabled: yes
+
+    # ── Cleanup ───────────────────────────────────────
+    - name: Remove smartctl_exporter archive
+      ansible.builtin.file:
+        path: /tmp/smartctl_exporter.tar.gz
+        state: absent
+
+  handlers:
+    - name: reload nfs exports
+      ansible.builtin.command: exportfs -ra
+
+    - name: restart sanoid timer
+      ansible.builtin.systemd:
+        name: sanoid.timer
+        state: restarted
+
+    - name: daemon reload
+      ansible.builtin.systemd:
+        daemon_reload: yes
+
+    - name: restart alloy
+      ansible.builtin.systemd:
+        name: alloy
+        state: restarted
+
+    - name: restart smartctl-exporter
+      ansible.builtin.systemd:
+        name: smartctl-exporter
+        state: restarted

--- a/proxmox/site.yml
+++ b/proxmox/site.yml
@@ -50,6 +50,15 @@
           - nfs-common
         state: present
 
+    - name: Ensure NFS export directories exist
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      loop: "{{ nfs_exports }}"
+
     - name: Configure NFS exports
       ansible.builtin.lineinfile:
         path: /etc/exports
@@ -110,9 +119,16 @@
         mode: "0644"
 
     - name: Dearmor and install Grafana GPG key
-      ansible.builtin.shell:
-        cmd: gpg --dearmor < /tmp/grafana-gpg.key > /etc/apt/keyrings/grafana.gpg
+      ansible.builtin.command:
+        cmd: gpg --batch --yes --dearmor --output /etc/apt/keyrings/grafana.gpg /tmp/grafana-gpg.key
         creates: /etc/apt/keyrings/grafana.gpg
+
+    - name: Set Grafana keyring permissions
+      ansible.builtin.file:
+        path: /etc/apt/keyrings/grafana.gpg
+        owner: root
+        group: root
+        mode: "0644"
 
     - name: Add Grafana APT repository
       ansible.builtin.apt_repository:
@@ -132,8 +148,8 @@
         src: alloy-config.alloy.j2
         dest: /etc/alloy/config.alloy
         owner: root
-        group: root
-        mode: "0644"
+        group: alloy
+        mode: "0640"
       notify: restart alloy
 
     - name: Deploy Alloy environment file
@@ -182,6 +198,7 @@
       ansible.builtin.get_url:
         url: "https://github.com/prometheus-community/smartctl_exporter/releases/download/v{{ smartctl_exporter_version }}/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64.tar.gz"
         dest: /tmp/smartctl_exporter.tar.gz
+        checksum: "sha256:{{ smartctl_exporter_checksum }}"
 
     - name: Extract smartctl_exporter
       ansible.builtin.unarchive:

--- a/proxmox/site.yml
+++ b/proxmox/site.yml
@@ -11,6 +11,33 @@
     - name: Gather facts
       ansible.builtin.setup:
 
+    # ── Local SSD Pool (VM/LXC storage) ──────────────
+    # Must run before lae.proxmox role which registers storage backends
+    - name: Check if local-ssd pool exists
+      ansible.builtin.command: zpool list {{ local_ssd_pool.name }}
+      register: local_ssd_pool_check
+      changed_when: false
+      failed_when: false
+
+    - name: Wipe old partition tables on local-ssd drives
+      ansible.builtin.command: sgdisk --zap-all {{ item }}
+      loop: "{{ local_ssd_pool.drives }}"
+      when: local_ssd_pool_check.rc != 0
+
+    - name: Create local-ssd ZFS mirror pool
+      ansible.builtin.command: >
+        zpool create
+        -o ashift={{ local_ssd_pool.properties.ashift }}
+        -O compression={{ local_ssd_pool.properties.compression }}
+        -O atime={{ local_ssd_pool.properties.atime }}
+        -O acltype=posixacl
+        -O xattr=sa
+        -O dnodesize=auto
+        {{ local_ssd_pool.name }}
+        {{ local_ssd_pool.vdev }}
+        {{ local_ssd_pool.drives | join(' ') }}
+      when: local_ssd_pool_check.rc != 0
+
   roles:
     - role: lae.proxmox
 

--- a/proxmox/templates/alloy-config.alloy.j2
+++ b/proxmox/templates/alloy-config.alloy.j2
@@ -49,8 +49,8 @@ prometheus.remote_write "prometheus" {
   endpoint {
     url = "{{ alloy_prometheus_url }}"
     basic_auth {
-      username = "{{ vault_alloy_basic_auth_username }}"
-      password = "{{ vault_alloy_basic_auth_password }}"
+      username = sys.env("BASIC_AUTH_USERNAME")
+      password = sys.env("BASIC_AUTH_PASSWORD")
     }
   }
 }
@@ -95,8 +95,8 @@ loki.write "loki" {
     url       = "{{ alloy_loki_url }}"
     tenant_id = "homelab"
     basic_auth {
-      username = "{{ vault_alloy_basic_auth_username }}"
-      password = "{{ vault_alloy_basic_auth_password }}"
+      username = sys.env("BASIC_AUTH_USERNAME")
+      password = sys.env("BASIC_AUTH_PASSWORD")
     }
   }
 }

--- a/proxmox/templates/alloy-config.alloy.j2
+++ b/proxmox/templates/alloy-config.alloy.j2
@@ -1,0 +1,102 @@
+// Alloy config for {{ alloy_instance_name }}
+// Managed by Ansible — do not edit manually
+
+// ============================================================
+// Host metrics (node_exporter)
+// ============================================================
+prometheus.exporter.unix "host" {
+  procfs_path = "/proc"
+  sysfs_path  = "/sys"
+  rootfs_path = "/"
+}
+
+prometheus.scrape "host" {
+  targets         = prometheus.exporter.unix.host.targets
+  forward_to      = [prometheus.relabel.instance.receiver]
+  scrape_interval = "60s"
+  job_name        = "node"
+}
+
+// ============================================================
+// SMART disk health (local smartctl_exporter)
+// ============================================================
+prometheus.scrape "smartctl" {
+  targets         = [{"__address__" = "{{ smartctl_exporter_listen }}"}]
+  forward_to      = [prometheus.relabel.instance.receiver]
+  scrape_interval = "120s"
+  job_name        = "smartctl"
+}
+
+// ============================================================
+// Relabel: add instance label
+// ============================================================
+prometheus.relabel "instance" {
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+  rule {
+    action       = "replace"
+    target_label = "instance"
+    replacement  = "{{ alloy_instance_name }}"
+  }
+}
+
+// ============================================================
+// Remote write: push metrics to K8s Prometheus
+// ============================================================
+prometheus.remote_write "prometheus" {
+  external_labels = {
+    source = "infra",
+  }
+  endpoint {
+    url = "{{ alloy_prometheus_url }}"
+    basic_auth {
+      username = "{{ vault_alloy_basic_auth_username }}"
+      password = "{{ vault_alloy_basic_auth_password }}"
+    }
+  }
+}
+
+// ============================================================
+// Host journal logs (syslog, kernel, hardware errors)
+// ============================================================
+loki.source.journal "host" {
+  forward_to = [loki.process.journal.receiver]
+  relabel_rules = loki.relabel.journal.rules
+  labels = {
+    job = "journal",
+  }
+}
+
+loki.relabel "journal" {
+  forward_to = []
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+  rule {
+    source_labels = ["__journal_priority_keyword"]
+    target_label  = "priority"
+  }
+}
+
+loki.process "journal" {
+  stage.static_labels {
+    values = {
+      instance = "{{ alloy_instance_name }}",
+    }
+  }
+  forward_to = [loki.write.loki.receiver]
+}
+
+// ============================================================
+// Loki write: push logs to K8s Loki
+// ============================================================
+loki.write "loki" {
+  endpoint {
+    url       = "{{ alloy_loki_url }}"
+    tenant_id = "homelab"
+    basic_auth {
+      username = "{{ vault_alloy_basic_auth_username }}"
+      password = "{{ vault_alloy_basic_auth_password }}"
+    }
+  }
+}

--- a/proxmox/templates/alloy-env.j2
+++ b/proxmox/templates/alloy-env.j2
@@ -1,0 +1,4 @@
+PROMETHEUS_URL={{ alloy_prometheus_url }}
+LOKI_URL={{ alloy_loki_url }}
+BASIC_AUTH_USERNAME={{ vault_alloy_basic_auth_username }}
+BASIC_AUTH_PASSWORD={{ vault_alloy_basic_auth_password }}

--- a/proxmox/templates/sanoid.conf.j2
+++ b/proxmox/templates/sanoid.conf.j2
@@ -1,0 +1,23 @@
+# Sanoid configuration — managed by Ansible
+{% for dataset in sanoid_datasets %}
+[{{ dataset.name }}]
+use_template = {{ dataset.template }}
+recursive = {{ 'yes' if dataset.recursive else 'no' }}
+
+{% endfor %}
+#############################
+# templates below this line #
+#############################
+
+{% for name, tmpl in sanoid_templates.items() %}
+[template_{{ name }}]
+frequently = {{ tmpl.frequently }}
+hourly = {{ tmpl.hourly }}
+daily = {{ tmpl.daily }}
+weekly = {{ tmpl.weekly }}
+monthly = {{ tmpl.monthly }}
+yearly = {{ tmpl.yearly }}
+autosnap = {{ 'yes' if tmpl.autosnap else 'no' }}
+autoprune = {{ 'yes' if tmpl.autoprune else 'no' }}
+
+{% endfor %}

--- a/proxmox/templates/smartctl-exporter.service.j2
+++ b/proxmox/templates/smartctl-exporter.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=Prometheus SMART disk metrics exporter
+Documentation=https://github.com/prometheus-community/smartctl_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/smartctl_exporter --web.listen-address={{ smartctl_exporter_listen }} --smartctl.interval={{ smartctl_exporter_interval }}
+Restart=on-failure
+RestartSec=10
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+NoNewPrivileges=true
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Add Ansible playbook (`proxmox/`) for R720XD Proxmox VE node configuration using `lae.proxmox` role
- Migrate secrets from ansible-vault to SOPS + age (consistent with K8s/Docker secret management)
- Update repo-level docs (README, CLAUDE.md) to include Proxmox as third infrastructure pillar
- Update pre-commit hooks and encrypt script to handle `.sops.yml` files

## What gets configured

**Via `lae.proxmox` role:** no-subscription repos, ZFS storage backends (pool0, ssdpool0), users/ACLs, datacenter config

**Via custom tasks:** NFS exports (`/mnt/pool0/nvr` for Frigate), Sanoid snapshot automation, Alloy observability agent, smartctl-exporter disk health

## Secrets

Uses `community.sops` Ansible vars plugin — auto-decrypts `*.sops.yml` files in `group_vars/` using the same age key as K8s and Docker. No ansible-vault dependency.

## Test plan

- [x] `ansible-playbook site.yml` run successfully on R720XD during TrueNAS → Proxmox migration
- [x] SOPS decryption verified: `ansible -m debug -a "var=vault_alloy_basic_auth_username" r720xd`
- [x] Pre-commit hooks pass with `.sops.yml` files
- [x] Alloy metrics flowing to Prometheus/Loki with `instance=r720xd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)