### PR TITLE
feat(proxmox): add pve03 node and refactor to multi-host playbook

### DIFF
--- a/proxmox/group_vars/all/vars.yml
+++ b/proxmox/group_vars/all/vars.yml
@@ -1,6 +1,6 @@
 ---
-# Proxmox VE Configuration - R720XD Standalone Node
-# Uses lae.proxmox role for base configuration
+# Proxmox VE Configuration — Shared across all nodes
+# Host-specific overrides in host_vars/{hostname}.yml
 
 # ── Core ────────────────────────────────────────────
 pve_group: all
@@ -18,42 +18,7 @@ pve_reboot_on_kernel_update: false
 
 # ── ZFS ─────────────────────────────────────────────
 pve_zfs_enabled: yes
-# 192GB ARC max (leaves 64GB for VMs/system out of 256GB total)
-pve_zfs_options: "zfs_arc_max=206158430208"
-
-# ── Storage Backends ────────────────────────────────
-# Pools must already be imported before running this playbook
-pve_storages:
-  - name: pool0-store
-    type: zfspool
-    content: ["images", "rootdir"]
-    pool: pool0
-    sparse: true
-
-  - name: ssdpool0-store
-    type: zfspool
-    content: ["images", "rootdir"]
-    pool: ssdpool0
-    sparse: true
-
-  - name: local-ssd
-    type: zfspool
-    content: ["images", "rootdir"]
-    pool: local-ssd
-    sparse: true
-
-# ── Local SSD Pool (VM/LXC storage) ────────────────
-# ZFS mirror on 2x Samsung 870 EVO 1TB (was TrueNAS ssdpool1)
-local_ssd_pool:
-  name: local-ssd
-  vdev: mirror
-  drives:
-    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909545W
-    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909519P
-  properties:
-    ashift: 12
-    compression: lz4
-    atime: "off"
+# pve_zfs_options set per-host in host_vars (ARC size depends on RAM)
 
 # ── Users ───────────────────────────────────────────
 pve_groups:
@@ -73,15 +38,8 @@ pve_acls:
 pve_datacenter_cfg:
   keyboard: en-us
 
-# ── NFS Export ──────────────────────────────────────
-# Not handled by lae.proxmox role — configured in site.yml tasks
-nfs_exports:
-  - path: /mnt/pool0/nvr
-    network: "192.168.11.0/24"
-    options: "rw,sync,no_subtree_check,no_root_squash"
-
-# ── Monitoring ──────────────────────────────────────
-alloy_instance_name: "r720xd"
+# ── Monitoring (shared) ─────────────────────────────
+# alloy_instance_name set per-host in host_vars
 alloy_prometheus_url: "https://prometheus.sharmamohit.com/api/v1/write"
 alloy_loki_url: "https://loki.sharmamohit.com/loki/api/v1/push"
 smartctl_exporter_version: "0.14.0"
@@ -89,15 +47,8 @@ smartctl_exporter_checksum: "875983cd27affc5a682401930e5a8eea3f06c325fe6d6a7228c
 smartctl_exporter_listen: "127.0.0.1:9633"
 smartctl_exporter_interval: "120s"
 
-# ── Sanoid (ZFS snapshots) ──────────────────────────
-sanoid_datasets:
-  - name: "pool0/nvr"
-    template: data_retention
-    recursive: yes
-  - name: "ssdpool0"
-    template: data_retention
-    recursive: yes
-
+# ── Sanoid (shared template) ────────────────────────
+# sanoid_datasets set per-host in host_vars
 sanoid_templates:
   data_retention:
     frequently: 0

--- a/proxmox/host_vars/pve03.yml
+++ b/proxmox/host_vars/pve03.yml
@@ -1,0 +1,22 @@
+---
+# pve03 — AMD Ryzen 5 8500G Mini PC, 30GB RAM, 1TB NVMe
+# IP: 192.168.11.12
+# Purpose: Media center (Jellyfin, *arr stack)
+
+# ── ZFS ARC ─────────────────────────────────────────
+# 4GB (leaves ~26GB for VMs/LXCs out of 30GB total)
+# rpool only serves OS + VM images, not bulk media
+pve_zfs_options: "zfs_arc_max=4294967296"
+
+# ── Storage Backends ────────────────────────────────
+# rpool/data (local-zfs) already configured by installer
+pve_storages: []
+
+# ── Monitoring ──────────────────────────────────────
+alloy_instance_name: "pve03"
+
+# ── Sanoid ──────────────────────────────────────────
+sanoid_datasets:
+  - name: "rpool"
+    template: data_retention
+    recursive: yes

--- a/proxmox/host_vars/r720xd.yml
+++ b/proxmox/host_vars/r720xd.yml
@@ -1,0 +1,58 @@
+---
+# R720XD — Dell R720XD, 256GB RAM, 14 drives
+# IP: 192.168.11.15
+
+# ── ZFS ARC ─────────────────────────────────────────
+# 192GB (leaves 64GB for VMs/system out of 256GB total)
+pve_zfs_options: "zfs_arc_max=206158430208"
+
+# ── Storage Backends ────────────────────────────────
+pve_storages:
+  - name: pool0-store
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: pool0
+    sparse: true
+
+  - name: ssdpool0-store
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: ssdpool0
+    sparse: true
+
+  - name: local-ssd
+    type: zfspool
+    content: ["images", "rootdir"]
+    pool: local-ssd
+    sparse: true
+
+# ── Local SSD Pool Creation ─────────────────────────
+# ZFS mirror on 2x Samsung 870 EVO 1TB (was TrueNAS ssdpool1)
+local_ssd_pool:
+  name: local-ssd
+  vdev: mirror
+  drives:
+    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909545W
+    - /dev/disk/by-id/ata-Samsung_SSD_870_EVO_1TB_S625NZ0R909519P
+  properties:
+    ashift: 12
+    compression: lz4
+    atime: "off"
+
+# ── NFS Export ──────────────────────────────────────
+nfs_exports:
+  - path: /mnt/pool0/nvr
+    network: "192.168.11.0/24"
+    options: "rw,sync,no_subtree_check,no_root_squash"
+
+# ── Monitoring ──────────────────────────────────────
+alloy_instance_name: "r720xd"
+
+# ── Sanoid ──────────────────────────────────────────
+sanoid_datasets:
+  - name: "pool0/nvr"
+    template: data_retention
+    recursive: yes
+  - name: "ssdpool0"
+    template: data_retention
+    recursive: yes

--- a/proxmox/inventory/hosts.yml
+++ b/proxmox/inventory/hosts.yml
@@ -5,3 +5,7 @@ all:
       ansible_host: 192.168.11.15
       ansible_user: root
       ansible_python_interpreter: /usr/bin/python3
+    pve03:
+      ansible_host: 192.168.11.12
+      ansible_user: root
+      ansible_python_interpreter: /usr/bin/python3

--- a/proxmox/site.yml
+++ b/proxmox/site.yml
@@ -12,17 +12,34 @@
       ansible.builtin.setup:
 
     # ── Local SSD Pool (R720XD only) ─────────────────
-    - name: Check if local-ssd pool exists
+    - name: Check if local-ssd pool is active
       ansible.builtin.command: zpool list {{ local_ssd_pool.name }}
-      register: local_ssd_pool_check
+      register: local_ssd_pool_active
       changed_when: false
       failed_when: false
       when: local_ssd_pool is defined
 
+    - name: Check if local-ssd pool is importable but not active
+      ansible.builtin.shell: zpool import 2>&1 | grep -q "pool:.*{{ local_ssd_pool.name }}"
+      register: local_ssd_pool_importable
+      changed_when: false
+      failed_when: false
+      when: local_ssd_pool is defined and local_ssd_pool_active.rc != 0
+
+    - name: Import existing local-ssd pool if found
+      ansible.builtin.command: zpool import {{ local_ssd_pool.name }}
+      when: >
+        local_ssd_pool is defined
+        and local_ssd_pool_active.rc != 0
+        and local_ssd_pool_importable.rc == 0
+
     - name: Wipe old partition tables on local-ssd drives
       ansible.builtin.command: sgdisk --zap-all {{ item }}
       loop: "{{ local_ssd_pool.drives }}"
-      when: local_ssd_pool is defined and local_ssd_pool_check.rc != 0
+      when: >
+        local_ssd_pool is defined
+        and local_ssd_pool_active.rc != 0
+        and local_ssd_pool_importable.rc != 0
 
     - name: Create local-ssd ZFS mirror pool
       ansible.builtin.command: >
@@ -36,7 +53,10 @@
         {{ local_ssd_pool.name }}
         {{ local_ssd_pool.vdev }}
         {{ local_ssd_pool.drives | join(' ') }}
-      when: local_ssd_pool is defined and local_ssd_pool_check.rc != 0
+      when: >
+        local_ssd_pool is defined
+        and local_ssd_pool_active.rc != 0
+        and local_ssd_pool_importable.rc != 0
 
   roles:
     - role: lae.proxmox
@@ -198,24 +218,25 @@
         name: smartmontools
         state: present
 
-    - name: Check if smartctl_exporter is already installed
-      ansible.builtin.stat:
-        path: /usr/local/bin/smartctl_exporter
-      register: smartctl_binary
+    - name: Check installed smartctl_exporter version
+      ansible.builtin.shell: /usr/local/bin/smartctl_exporter --version 2>&1 | grep -q "version {{ smartctl_exporter_version }}"
+      register: smartctl_version_match
+      changed_when: false
+      failed_when: false
 
     - name: Download smartctl_exporter
       ansible.builtin.get_url:
         url: "https://github.com/prometheus-community/smartctl_exporter/releases/download/v{{ smartctl_exporter_version }}/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64.tar.gz"
         dest: /tmp/smartctl_exporter.tar.gz
         checksum: "sha256:{{ smartctl_exporter_checksum }}"
-      when: not smartctl_binary.stat.exists
+      when: smartctl_version_match.rc != 0
 
     - name: Extract smartctl_exporter
       ansible.builtin.unarchive:
         src: /tmp/smartctl_exporter.tar.gz
         dest: /tmp/
         remote_src: yes
-      when: not smartctl_binary.stat.exists
+      when: smartctl_version_match.rc != 0
 
     - name: Install smartctl_exporter binary
       ansible.builtin.copy:
@@ -225,8 +246,17 @@
         group: root
         mode: "0755"
         remote_src: yes
-      when: not smartctl_binary.stat.exists
+      when: smartctl_version_match.rc != 0
       notify: restart smartctl-exporter
+
+    - name: Clean up smartctl_exporter temp files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /tmp/smartctl_exporter.tar.gz
+        - "/tmp/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64"
+      when: smartctl_version_match.rc != 0
 
     - name: Deploy smartctl-exporter systemd service
       ansible.builtin.template:
@@ -244,12 +274,6 @@
         name: smartctl-exporter
         state: started
         enabled: yes
-
-    # ── Cleanup ───────────────────────────────────────
-    - name: Remove smartctl_exporter archive
-      ansible.builtin.file:
-        path: /tmp/smartctl_exporter.tar.gz
-        state: absent
 
   handlers:
     - name: reload nfs exports

--- a/proxmox/site.yml
+++ b/proxmox/site.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure Proxmox VE on R720XD
+- name: Configure Proxmox VE nodes
   hosts: all
   become: true
 
@@ -11,18 +11,18 @@
     - name: Gather facts
       ansible.builtin.setup:
 
-    # ── Local SSD Pool (VM/LXC storage) ──────────────
-    # Must run before lae.proxmox role which registers storage backends
+    # ── Local SSD Pool (R720XD only) ─────────────────
     - name: Check if local-ssd pool exists
       ansible.builtin.command: zpool list {{ local_ssd_pool.name }}
       register: local_ssd_pool_check
       changed_when: false
       failed_when: false
+      when: local_ssd_pool is defined
 
     - name: Wipe old partition tables on local-ssd drives
       ansible.builtin.command: sgdisk --zap-all {{ item }}
       loop: "{{ local_ssd_pool.drives }}"
-      when: local_ssd_pool_check.rc != 0
+      when: local_ssd_pool is defined and local_ssd_pool_check.rc != 0
 
     - name: Create local-ssd ZFS mirror pool
       ansible.builtin.command: >
@@ -36,19 +36,20 @@
         {{ local_ssd_pool.name }}
         {{ local_ssd_pool.vdev }}
         {{ local_ssd_pool.drives | join(' ') }}
-      when: local_ssd_pool_check.rc != 0
+      when: local_ssd_pool is defined and local_ssd_pool_check.rc != 0
 
   roles:
     - role: lae.proxmox
 
   tasks:
-    # ── NFS Export ────────────────────────────────────
+    # ── NFS Export (only hosts with nfs_exports defined) ──
     - name: Install NFS kernel server
       ansible.builtin.apt:
         name:
           - nfs-kernel-server
           - nfs-common
         state: present
+      when: nfs_exports is defined and nfs_exports | length > 0
 
     - name: Ensure NFS export directories exist
       ansible.builtin.file:
@@ -58,6 +59,7 @@
         group: root
         mode: "0755"
       loop: "{{ nfs_exports }}"
+      when: nfs_exports is defined
 
     - name: Configure NFS exports
       ansible.builtin.lineinfile:
@@ -66,6 +68,7 @@
         regexp: "^{{ item.path | regex_escape }}\\s"
         create: yes
       loop: "{{ nfs_exports }}"
+      when: nfs_exports is defined
       notify: reload nfs exports
 
     - name: Enable and start NFS server
@@ -73,6 +76,7 @@
         name: nfs-kernel-server
         state: started
         enabled: yes
+      when: nfs_exports is defined and nfs_exports | length > 0
 
     # ── Sanoid (ZFS Snapshots) ────────────────────────
     - name: Install Sanoid
@@ -194,17 +198,24 @@
         name: smartmontools
         state: present
 
+    - name: Check if smartctl_exporter is already installed
+      ansible.builtin.stat:
+        path: /usr/local/bin/smartctl_exporter
+      register: smartctl_binary
+
     - name: Download smartctl_exporter
       ansible.builtin.get_url:
         url: "https://github.com/prometheus-community/smartctl_exporter/releases/download/v{{ smartctl_exporter_version }}/smartctl_exporter-{{ smartctl_exporter_version }}.linux-amd64.tar.gz"
         dest: /tmp/smartctl_exporter.tar.gz
         checksum: "sha256:{{ smartctl_exporter_checksum }}"
+      when: not smartctl_binary.stat.exists
 
     - name: Extract smartctl_exporter
       ansible.builtin.unarchive:
         src: /tmp/smartctl_exporter.tar.gz
         dest: /tmp/
         remote_src: yes
+      when: not smartctl_binary.stat.exists
 
     - name: Install smartctl_exporter binary
       ansible.builtin.copy:
@@ -214,6 +225,7 @@
         group: root
         mode: "0755"
         remote_src: yes
+      when: not smartctl_binary.stat.exists
       notify: restart smartctl-exporter
 
     - name: Deploy smartctl-exporter systemd service


### PR DESCRIPTION
## Summary

- Add pve03 (AMD Ryzen 5 8500G, 30GB RAM, 1TB NVMe) as second Proxmox node
- Refactor Ansible vars to support multi-host: shared config in `group_vars/all/`, host-specific in `host_vars/`
- Fix playbook idempotency issues (enterprise repo flip-flop, smartctl re-download)

## Changes

- `inventory/hosts.yml` — added pve03 (192.168.11.12)
- `group_vars/all/vars.yml` — extracted shared vars (repos, users, monitoring URLs, sanoid templates)
- `host_vars/r720xd.yml` — R720XD-specific (192GB ARC, 3 storage pools, NFS exports, sanoid datasets)
- `host_vars/pve03.yml` — pve03-specific (4GB ARC, sanoid on rpool, instance=pve03)
- `site.yml` — conditional tasks (NFS/local-ssd only where defined), removed redundant enterprise repo tasks, smartctl install idempotency

## pve03 config

| Property | Value |
|----------|-------|
| ZFS ARC | 4GB (of 30GB) |
| Sanoid | rpool (recursive) |
| Monitoring | Alloy (instance=pve03) + smartctl-exporter |
| Storage | rpool/data (local-zfs, installer default) |

## Test plan

- [x] `ansible-playbook site.yml -l pve03` — 77 ok, 0 failed
- [x] `ansible-playbook site.yml -l r720xd` — 73 ok, 0 changed (idempotent)
- [x] `ansible-playbook site.yml -l pve03` second run — 66 ok, 0 changed (idempotent)
- [x] Grafana: `up{instance="pve03"}` returning data

🤖 Generated with [Claude Code](https://claude.com/claude-code)