### PR TITLE
fix(media-stack): raise LXC memory and fix silent-host alerting

### DIFF
--- a/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/argocd-apps/apps/kube-prometheus-stack.yaml
@@ -900,7 +900,7 @@ spec:
                                   params: [1]
                             refId: C
                       for: 5m
-                      noDataState: NoData
+                      noDataState: Alerting
                       execErrState: Error
                       labels:
                         severity: critical
@@ -937,12 +937,52 @@ spec:
                                   params: [1]
                             refId: C
                       for: 5m
-                      noDataState: NoData
+                      noDataState: Alerting
                       execErrState: Error
                       labels:
                         severity: critical
                       annotations:
                         summary: 'Jellyfin on media-stack is not responding to Prometheus scrapes'
+                        runbook_url: 'https://github.com/mohitsharma44/homeops/blob/main/docs/runbooks/media-stack-alerts.md#mediacontainerdown'
+                    # Host-level liveness canary: fires when Alloy on media-stack
+                    # stops remote-writing entirely (LXC down, OOM, network loss).
+                    # One alert replaces the NoData-brittleness of per-service rules.
+                    - uid: media-stack-host-absent
+                      title: MediaStackHostAbsent
+                      condition: C
+                      data:
+                        - refId: A
+                          relativeTimeRange:
+                            from: 600
+                            to: 0
+                          datasourceUid: thanos
+                          model:
+                            expr: 'absent(up{instance="media-stack"})'
+                            refId: A
+                        - refId: B
+                          datasourceUid: __expr__
+                          model:
+                            type: reduce
+                            expression: A
+                            reducer: last
+                            refId: B
+                        - refId: C
+                          datasourceUid: __expr__
+                          model:
+                            type: threshold
+                            expression: B
+                            conditions:
+                              - evaluator:
+                                  type: gt
+                                  params: [0]
+                            refId: C
+                      for: 5m
+                      noDataState: Alerting
+                      execErrState: Error
+                      labels:
+                        severity: critical
+                      annotations:
+                        summary: 'media-stack host is not reporting any metrics — LXC likely down'
                         runbook_url: 'https://github.com/mohitsharma44/homeops/blob/main/docs/runbooks/media-stack-alerts.md#mediacontainerdown'
                     - uid: media-decypharr-fuse-unhealthy
                       title: MediaDecypharrFuseUnhealthy

--- a/proxmox/host_vars/pve03.yml
+++ b/proxmox/host_vars/pve03.yml
@@ -28,7 +28,7 @@ media_stack_ip: "192.168.11.40"
 media_stack_gateway: "192.168.11.1"
 media_stack_nameserver: "192.168.11.1 9.9.9.9"
 media_stack_cores: 4
-media_stack_memory: 16384
+media_stack_memory: 20480
 media_stack_swap: 2048
 media_stack_disk_size: 256
 media_stack_storage: "local-zfs"


### PR DESCRIPTION
## Summary
- LXC 400 (media-stack) OOM-killed itself on 2026-04-13 ~20:19 UTC; OOM cascade reached systemd (pid 1) inside the container, crashing the LXC. No alert fired because every media-stack rule had `noDataState: NoData`.
- Bump LXC memory 16 GB → 20 GB (pve03 has 30 GB total, ZFS ARC capped at 4 GB — ample headroom).
- Flip `noDataState` → `Alerting` on `MediaJellyfinDown` and `MediaArrServiceDown` so missing metrics page instead of disappearing.
- Add `MediaStackHostAbsent`: `absent(up{instance="media-stack"})` — one canary covering any failure mode that kills Alloy remote-write (LXC down, OOM, network loss).

## Test plan
- [ ] Ansible play (or manual `pct set 400 -memory 20480`) applies new memory limit to LXC 400
- [ ] Grafana reloads alert rules, new `MediaStackHostAbsent` rule appears in `media-stack` group with state `inactive`
- [ ] Stop Alloy on media-stack for 5+ minutes → verify `MediaStackHostAbsent` fires
- [ ] Restart Alloy → verify alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)